### PR TITLE
Update Wireless SSID number in meraki_wireless.tf

### DIFF
--- a/meraki_wireless.tf
+++ b/meraki_wireless.tf
@@ -162,8 +162,8 @@ locals {
 resource "meraki_wireless_ssid" "net_wireless_ssids" {
   for_each   = { for i, v in local.networks_wireless_ssids : i => v }
   network_id = each.value.network_id
-  number     = each.key
 
+  number                                                                      = try(tonumber(each.value.data.number) + 1, tonumber(local.defaults.meraki.networks.networks_wireless_ssids.number) + 1, null)
   name                                                                        = try(each.value.data.name, local.defaults.meraki.networks.networks_wireless_ssids.name, null)
   enabled                                                                     = try(each.value.data.enabled, local.defaults.meraki.networks.networks_wireless_ssids.enabled, null)
   auth_mode                                                                   = try(each.value.data.auth_mode, local.defaults.meraki.networks.networks_wireless_ssids.auth_mode, null)

--- a/meraki_wireless.tf
+++ b/meraki_wireless.tf
@@ -163,7 +163,7 @@ resource "meraki_wireless_ssid" "net_wireless_ssids" {
   for_each   = { for i, v in local.networks_wireless_ssids : i => v }
   network_id = each.value.network_id
 
-  number                                                                      = try(tonumber(each.value.data.number) - 1, tonumber(local.defaults.meraki.networks.networks_wireless_ssids.number) - 1, null)
+  number                                                                      = try(each.value.data.number, local.defaults.meraki.networks.networks_wireless_ssids.number, null)
   name                                                                        = try(each.value.data.name, local.defaults.meraki.networks.networks_wireless_ssids.name, null)
   enabled                                                                     = try(each.value.data.enabled, local.defaults.meraki.networks.networks_wireless_ssids.enabled, null)
   auth_mode                                                                   = try(each.value.data.auth_mode, local.defaults.meraki.networks.networks_wireless_ssids.auth_mode, null)

--- a/meraki_wireless.tf
+++ b/meraki_wireless.tf
@@ -163,7 +163,7 @@ resource "meraki_wireless_ssid" "net_wireless_ssids" {
   for_each   = { for i, v in local.networks_wireless_ssids : i => v }
   network_id = each.value.network_id
 
-  number                                                                      = try(tonumber(each.value.data.number) + 1, tonumber(local.defaults.meraki.networks.networks_wireless_ssids.number) + 1, null)
+  number                                                                      = try(tonumber(each.value.data.number) - 1, tonumber(local.defaults.meraki.networks.networks_wireless_ssids.number) - 1, null)
   name                                                                        = try(each.value.data.name, local.defaults.meraki.networks.networks_wireless_ssids.name, null)
   enabled                                                                     = try(each.value.data.enabled, local.defaults.meraki.networks.networks_wireless_ssids.enabled, null)
   auth_mode                                                                   = try(each.value.data.auth_mode, local.defaults.meraki.networks.networks_wireless_ssids.auth_mode, null)


### PR DESCRIPTION
"number" is the [wireless SSID number](https://github.com/CiscoDevNet/terraform-provider-meraki/blob/02646e13559825d0bde822a0daf83e53431d1ce8/docs/resources/wireless_ssid.md). 15 ssids can be used, which are addressed via number 0-14, therefore each.key cannot be used. 