### PR TITLE
chore: changing org_snmp to match 1.53 schema changes for v2c and v3

### DIFF
--- a/meraki_organization.tf
+++ b/meraki_organization.tf
@@ -122,8 +122,8 @@ locals {
     for domain in try(local.meraki.domains, []) : [
       for org in try(domain.organizations, []) : {
         organization_id = meraki_organization.organization[org.name].id
-        v2c_enabled     = try(org.snmp.v2c_enabled, local.defaults.meraki.organizations.snmp.v2c_enabled, null)
-        v3_enabled      = try(org.snmp.v3_enabled, local.defaults.meraki.organizations.snmp.v3_enabled, null)
+        v2c             = try(org.snmp.v2c, local.defaults.meraki.organizations.snmp.v2c, null)
+        v3              = try(org.snmp.v3, local.defaults.meraki.organizations.snmp.v3, null)
         v3_auth_mode    = try(org.snmp.v3_auth_mode, local.defaults.meraki.organizations.snmp.v3_auth_mode, null)
         v3_auth_pass    = try(org.snmp.v3_auth_pass, local.defaults.meraki.organizations.snmp.v3_auth_pass, null)
         v3_priv_mode    = try(org.snmp.v3_priv_mode, local.defaults.meraki.organizations.snmp.v3_priv_mode, null)
@@ -137,8 +137,8 @@ resource "meraki_organization_snmp" "snmp" {
   for_each = { for i, v in local.snmp : i => v }
 
   organization_id = each.value.organization_id
-  v2c_enabled     = each.value.v2c_enabled
-  v3_enabled      = each.value.v3_enabled
+  v2c_enabled     = each.value.v2c
+  v3_enabled      = each.value.v3
   v3_auth_mode    = each.value.v3_auth_mode
   v3_auth_pass    = each.value.v3_auth_pass
   v3_priv_mode    = each.value.v3_priv_mode


### PR DESCRIPTION
Changing module to match new schema changes requested by Daniel.

organizations_snmp:
  v3_auth_mode: enum('MD5', 'SHA', required=False)
  v3_auth_pass: str(min=6, max=64, required=False)
  v3_priv_mode: enum('AES128', 'DES', required=False)
  v3_priv_pass: str(min=6, max=64, required=False)
  peer_ips: list(ip(required=False), required=False)
  v2c: bool(required=False)
  v3: bool(required=False)