### PR TITLE
versions: Update CiscoDevNet/meraki to 0.1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ module "meraki" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.5.2 |
-| <a name="requirement_meraki"></a> [meraki](#requirement\_meraki) | >= 0.1.9 |
+| <a name="requirement_meraki"></a> [meraki](#requirement\_meraki) | >= 0.1.12 |
 | <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.2.6 |
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     meraki = {
       source  = "CiscoDevNet/meraki"
-      version = ">= 0.1.9"
+      version = ">= 0.1.12"
     }
 
     utils = {


### PR DESCRIPTION
To get https://github.com/CiscoDevNet/terraform-provider-meraki/pull/66 for https://github.com/netascode/terraform-meraki-nac-meraki/pull/45.