### PR TITLE
Fix issues noticed during the refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module "meraki" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_meraki"></a> [meraki](#requirement\_meraki) | >= 0.1.12 |
+| <a name="requirement_meraki"></a> [meraki](#requirement\_meraki) | >= 1.1.0 |
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -583,7 +583,7 @@ locals {
           mode       = try(network.appliance.vpn_site_to_site_vpn.mode, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.mode, null)
           hubs = try(length(network.appliance.vpn_site_to_site_vpn.hubs) == 0, true) ? null : [
             for hub in try(network.appliance.vpn_site_to_site_vpn.hubs, []) : {
-              hub_id            = try(hub.hub_id, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.hubs.hub_id, null)
+              hub_id            = meraki_network.organizations_networks[format("%s/%s/%s", domain.name, organization.name, hub.hub_network_name)].id
               use_default_route = try(hub.use_default_route, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.hubs.use_default_route, null)
             }
           ]

--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -581,20 +581,21 @@ locals {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = meraki_network.organizations_networks[format("%s/%s/%s", domain.name, organization.name, network.name)].id
           mode       = try(network.appliance.vpn_site_to_site_vpn.mode, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.mode, null)
+          hubs = try(length(network.appliance.vpn_site_to_site_vpn.hubs) == 0, true) ? null : [
+            for hub in try(network.appliance.vpn_site_to_site_vpn.hubs, []) : {
+              hub_id            = try(hub.hub_id, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.hubs.hub_id, null)
+              use_default_route = try(hub.use_default_route, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.hubs.use_default_route, null)
+            }
+          ]
           subnets = try(length(network.appliance.vpn_site_to_site_vpn.subnets) == 0, true) ? null : [
             for subnet in try(network.appliance.vpn_site_to_site_vpn.subnets, []) : {
               local_subnet      = try(subnet.local_subnet, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.subnets.local_subnet, null)
+              use_vpn           = try(subnet.use_vpn, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.subnets.use_vpn, null)
               nat_enabled       = try(subnet.nat.enabled, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.subnets.nat.enabled, null)
               nat_remote_subnet = try(subnet.nat.remote_subnet, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.subnets.nat.remote_subnet, null)
-              use_vpn           = try(subnet.use_vpn, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.subnets.use_vpn, null)
             }
           ]
-          hubs = try(length(network.appliance.vpn_site_to_site_vpn.hubs) == 0, true) ? null : [
-            for hub in try(network.appliance.vpn_site_to_site_vpn.hubs, []) : {
-              use_default_route = try(hub.use_default_route, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.hubs.use_default_route, null)
-              hub_id            = meraki_network.organizations_networks[format("%s/%s/%s", domain.name, organization.name, hub.hub_network_name)].id
-            }
-          ]
+          subnet_nat_is_allowed = try(network.appliance.vpn_site_to_site_vpn.subnet_nat, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.subnet_nat, null)
         } if try(network.appliance.vpn_site_to_site_vpn, null) != null
       ]
     ]
@@ -602,12 +603,13 @@ locals {
 }
 
 resource "meraki_appliance_site_to_site_vpn" "networks_appliance_vpn_site_to_site_vpn" {
-  for_each   = { for v in local.networks_appliance_vpn_site_to_site_vpn : v.key => v }
-  network_id = each.value.network_id
-  mode       = each.value.mode
-  hubs       = each.value.hubs
-  subnets    = each.value.subnets
-  depends_on = [meraki_network_device_claim.networks_devices_claim, meraki_appliance_single_lan.networks_appliance_single_lan, meraki_appliance_vlan.networks_appliance_vlans]
+  for_each              = { for v in local.networks_appliance_vpn_site_to_site_vpn : v.key => v }
+  network_id            = each.value.network_id
+  mode                  = each.value.mode
+  hubs                  = each.value.hubs
+  subnets               = each.value.subnets
+  subnet_nat_is_allowed = each.value.subnet_nat_is_allowed
+  depends_on            = [meraki_network_device_claim.networks_devices_claim, meraki_appliance_single_lan.networks_appliance_single_lan, meraki_appliance_vlan.networks_appliance_vlans]
 }
 
 locals {

--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -519,7 +519,7 @@ locals {
           key           = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id    = meraki_network.organizations_networks[format("%s/%s/%s", domain.name, organization.name, network.name)].id
           vlans_enabled = try(length(network.appliance.vlans) > 0, false)
-        } if try(length(network.appliance.vlans) > 0, false)
+        } if try(network.appliance, null) != null
       ]
     ]
   ])

--- a/meraki_organization.tf
+++ b/meraki_organization.tf
@@ -460,7 +460,7 @@ locals {
             syslog_enabled = try(rule.syslog, local.defaults.meraki.domains.organizations.appliance.vpn_firewall_rules.rules.syslog, null)
           }
         ]
-        syslog_default_rule = try(organization.appliance.vpn_firewall_rules.syslog_default_rule, local.defaults.meraki.organizations.appliance.vpn_firewall_rules.syslog_default_rule, null)
+        syslog_default_rule = try(organization.appliance.vpn_firewall_rules.syslog_default_rule, local.defaults.meraki.domains.organizations.appliance.vpn_firewall_rules.syslog_default_rule, null)
       } if length(try(organization.appliance.vpn_firewall_rules.rules, [])) > 0
     ]
   ])

--- a/meraki_organization.tf
+++ b/meraki_organization.tf
@@ -407,28 +407,30 @@ locals {
       for organization in try(domain.organizations, []) : {
         key             = format("%s/%s", domain.name, organization.name)
         organization_id = local.organization_ids[format("%s/%s", domain.name, organization.name)]
-        peers = try(length(organization.appliance.third_party_vpn_peers) == 0, true) ? null : [
-          for peer in try(organization.appliance.third_party_vpn_peers, []) : {
-            name                                    = try(peer.name, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.name, null)
-            public_ip                               = try(peer.public_ip, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.public_ip, null)
-            remote_id                               = try(peer.remote_id, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.remote_id, null)
-            secret                                  = try(peer.secret, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.secret, null)
-            ike_version                             = try(peer.ike_version, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ike_version, null)
-            local_id                                = try(peer.local_id, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.local_id, null)
-            private_subnets                         = try(peer.private_subnets, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.private_subnets, null)
-            network_tags                            = try(peer.network_tags, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.network_tags, null)
-            ipsec_policies_ike_cipher_algo          = try(peer.ipsec_policies.ike_cipher_algo, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.ike_cipher_algo, null)
-            ipsec_policies_ike_auth_algo            = try(peer.ipsec_policies.ike_auth_algo, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.ike_auth_algo, null)
-            ipsec_policies_ike_prf_algo             = try(peer.ipsec_policies.ike_prf_algo, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.ike_prf_algo, null)
-            ipsec_policies_ike_diffie_hellman_group = try(peer.ipsec_policies.ike_diffie_hellman_group, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.ike_diffie_hellman_group, null)
-            ipsec_policies_ike_lifetime             = try(peer.ipsec_policies.ike_lifetime, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.ike_lifetime, null)
-            ipsec_policies_child_cipher_algo        = try(peer.ipsec_policies.child_cipher_algo, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.child_cipher_algo, null)
-            ipsec_policies_child_auth_algo          = try(peer.ipsec_policies.child_auth_algo, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.child_auth_algo, null)
-            ipsec_policies_child_pfs_group          = try(peer.ipsec_policies.child_pfs_group, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.child_pfs_group, null)
-            ipsec_policies_child_lifetime           = try(peer.ipsec_policies.child_lifetime, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.child_lifetime, null)
+        peers = [
+          for appliance_third_party_vpn_peer in try(organization.appliance.third_party_vpn_peers, []) : {
+            name                                    = try(appliance_third_party_vpn_peer.name, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.name, null)
+            public_ip                               = try(appliance_third_party_vpn_peer.public_ip, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.public_ip, null)
+            public_hostname                         = try(appliance_third_party_vpn_peer.public_hostname, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.public_hostname, null)
+            private_subnets                         = try(appliance_third_party_vpn_peer.private_subnets, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.private_subnets, null)
+            local_id                                = try(appliance_third_party_vpn_peer.local_id, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.local_id, null)
+            remote_id                               = try(appliance_third_party_vpn_peer.remote_id, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.remote_id, null)
+            ipsec_policies_ike_cipher_algo          = try(appliance_third_party_vpn_peer.ipsec_policies.ike_cipher_algo, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.ike_cipher_algo, null)
+            ipsec_policies_ike_auth_algo            = try(appliance_third_party_vpn_peer.ipsec_policies.ike_auth_algo, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.ike_auth_algo, null)
+            ipsec_policies_ike_prf_algo             = try(appliance_third_party_vpn_peer.ipsec_policies.ike_prf_algo, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.ike_prf_algo, null)
+            ipsec_policies_ike_diffie_hellman_group = try(appliance_third_party_vpn_peer.ipsec_policies.ike_diffie_hellman_group, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.ike_diffie_hellman_group, null)
+            ipsec_policies_ike_lifetime             = try(appliance_third_party_vpn_peer.ipsec_policies.ike_lifetime, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.ike_lifetime, null)
+            ipsec_policies_child_cipher_algo        = try(appliance_third_party_vpn_peer.ipsec_policies.child_cipher_algo, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.child_cipher_algo, null)
+            ipsec_policies_child_auth_algo          = try(appliance_third_party_vpn_peer.ipsec_policies.child_auth_algo, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.child_auth_algo, null)
+            ipsec_policies_child_pfs_group          = try(appliance_third_party_vpn_peer.ipsec_policies.child_pfs_group, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.child_pfs_group, null)
+            ipsec_policies_child_lifetime           = try(appliance_third_party_vpn_peer.ipsec_policies.child_lifetime, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies.child_lifetime, null)
+            ipsec_policies_preset                   = try(appliance_third_party_vpn_peer.ipsec_policies_preset, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ipsec_policies_preset, null)
+            secret                                  = try(appliance_third_party_vpn_peer.secret, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.secret, null)
+            ike_version                             = try(appliance_third_party_vpn_peer.ike_version, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.ike_version, null)
+            network_tags                            = try(appliance_third_party_vpn_peer.network_tags, local.defaults.meraki.domains.organizations.appliance.third_party_vpn_peers.network_tags, null)
           }
         ]
-      } if length(try(organization.appliance.third_party_vpn_peers, [])) > 0
+      } if try(organization.appliance.third_party_vpn_peers, null) != null
     ]
   ])
 }

--- a/meraki_organization.tf
+++ b/meraki_organization.tf
@@ -460,14 +460,16 @@ locals {
             syslog_enabled = try(rule.syslog, local.defaults.meraki.domains.organizations.appliance.vpn_firewall_rules.rules.syslog, null)
           }
         ]
+        syslog_default_rule = try(organization.appliance.vpn_firewall_rules.syslog_default_rule, local.defaults.meraki.organizations.appliance.vpn_firewall_rules.syslog_default_rule, null)
       } if length(try(organization.appliance.vpn_firewall_rules.rules, [])) > 0
     ]
   ])
 }
 
 resource "meraki_appliance_vpn_firewall_rules" "organizations_appliance_vpn_firewall_rules" {
-  for_each        = { for v in local.organizations_appliance_vpn_firewall_rules : v.key => v }
-  organization_id = each.value.organization_id
-  rules           = each.value.rules
-  depends_on      = [meraki_network.organizations_networks]
+  for_each            = { for v in local.organizations_appliance_vpn_firewall_rules : v.key => v }
+  organization_id     = each.value.organization_id
+  rules               = each.value.rules
+  syslog_default_rule = each.value.syslog_default_rule
+  depends_on          = [meraki_network.organizations_networks]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     meraki = {
       source  = "CiscoDevNet/meraki"
-      version = ">= 0.1.12"
+      version = ">= 1.1.0"
     }
   }
 }


### PR DESCRIPTION
Fix issues noticed during #47 and #53 that were dependent on other things being fixed.
- `meraki_organization`: `organizations_appliance_third_party_vpn_peers`: Add missing fields - regenerate fields
  - `public_hostname`. Note: Meraki API returns an error if both `public_hostname` and `public_ip` are specified.
  - `ipsec_policies_preset`. Note: Meraki API ignores `ipsec_policies` if `ipsec_policies_preset` is specified. Idempotency breaks in that case.
- `meraki_organization`: `organizations_vpn_firewall_rules`: Add missing `syslog_default_rule` field
  - Add dependency on provider 1.1.0 (to get https://github.com/CiscoDevNet/terraform-provider-meraki/issues/73)
- `meraki_appliance`: `networks_appliance_vpn_site_to_site_vpn`: Add missing subnet_nat_is_allowed field - regenerate fields
  - Note: this feature [must be enabled by Meraki support](https://documentation.meraki.com/MX/Site-to-site_VPN/Using_Site-to-site_VPN_Translation). Meraki API returns an error when it is not enabled. Having it enabled has not been tested.
- `meraki_appliance`: `networks_appliance_vlans_settings`: Create the resource if no VLANs are configured.
  - #47 (the part done manually) changed this to create the resource only if at least one VLAN is specified. Since the only value the resource sets is `length(vlans) > 0`, it's not possible to have it set to `false` after that change. It was originally created if `domains.organizations` are specified, which was always, since `networks` are under `organizations`.
  - Change this to create the resource if `network.appliance` is specified instead.