### PR TITLE
Fix null handiling for Devices_switch_port & switches_port_schedule

### DIFF
--- a/meraki_devices.tf
+++ b/meraki_devices.tf
@@ -177,7 +177,7 @@ locals {
                 device_serial            = meraki_device.devices[format("%s/%s/%s/%s", domain.name, organization.name, network.name, device.name)].serial
                 port_id                  = port_id
                 data                     = switch_port
-                port_schedule_id         = meraki_switch_port_schedule.networks_switch_port_schedules[format("%s/%s/%s/%s", domain.name, organization.name, network.name, switch_port.port_schedule_name)].id
+                port_schedule_id         = try(meraki_switch_port_schedule.networks_switch_port_schedules[format("%s/%s/%s/%s", domain.name, organization.name, network.name, switch_port.port_schedule_name)].id, null)
                 adaptive_policy_group_id = try(meraki_organization_adaptive_policy_group.organizations_adaptive_policy_groups[format("%s/%s/%s", domain.name, organization.name, switch_port.adaptive_policy_group_name)].id, null)
               } if replace(port_id, "-", "") == port_id
             ]
@@ -198,7 +198,7 @@ locals {
                     device_serial            = meraki_device.devices[format("%s/%s/%s/%s", domain.name, organization.name, network.name, device.name)].serial
                     port_id                  = p
                     data                     = switch_port
-                    port_schedule_id         = meraki_switch_port_schedule.networks_switch_port_schedules[format("%s/%s/%s/%s", domain.name, organization.name, network.name, switch_port.port_schedule_name)].id
+                    port_schedule_id         = try(meraki_switch_port_schedule.networks_switch_port_schedules[format("%s/%s/%s/%s", domain.name, organization.name, network.name, switch_port.port_schedule_name)].id, null)
                     adaptive_policy_group_id = try(meraki_organization_adaptive_policy_group.organizations_adaptive_policy_groups[format("%s/%s/%s", domain.name, organization.name, switch_port.adaptive_policy_group_name)].id, null)
                   }
                 ] if replace(port_range, "-", "") != port_range

--- a/meraki_switches.tf
+++ b/meraki_switches.tf
@@ -322,7 +322,7 @@ locals {
             port_schedule_sunday_active    = try(switch_port_schedule.port_schedule.sunday.active, local.defaults.meraki.domains.organizations.networks.switch.port_schedules.port_schedule.sunday.active, null)
             port_schedule_sunday_from      = try(switch_port_schedule.port_schedule.sunday.from, local.defaults.meraki.domains.organizations.networks.switch.port_schedules.port_schedule.sunday.from, null)
             port_schedule_sunday_to        = try(switch_port_schedule.port_schedule.sunday.to, local.defaults.meraki.domains.organizations.networks.switch.port_schedules.port_schedule.sunday.to, null)
-          } if try(network.switch.port_schedules, null) != null
+          }
         ]
       ]
     ]

--- a/meraki_switches.tf
+++ b/meraki_switches.tf
@@ -322,7 +322,7 @@ locals {
             port_schedule_sunday_active    = try(switch_port_schedule.port_schedule.sunday.active, local.defaults.meraki.domains.organizations.networks.switch.port_schedules.port_schedule.sunday.active, null)
             port_schedule_sunday_from      = try(switch_port_schedule.port_schedule.sunday.from, local.defaults.meraki.domains.organizations.networks.switch.port_schedules.port_schedule.sunday.from, null)
             port_schedule_sunday_to        = try(switch_port_schedule.port_schedule.sunday.to, local.defaults.meraki.domains.organizations.networks.switch.port_schedules.port_schedule.sunday.to, null)
-          }
+          } if try(network.switch.port_schedules, null) != null
         ]
       ]
     ]


### PR DESCRIPTION
An error is observed during testing when no data is passed for port_schedules to either the local meraki_switch_port_schedules or device_switch_ports locals.

To change this as per other modules we add the following 

try(network.switch.port_schedules, null)

	•	Attempts to access network.switch.port_schedules
	•	If any part of that path is missing (network, switch, or port_schedules), it does not error, and instead returns null

Then finally, != null

	•	Checks if the result of the try(...) is not null
	•	If it’s not null, it means port_schedules exists 
