### PR TITLE
networks_appliance_sdwan_internet_policies: Fix intermittent deletion error

### DIFF
--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -715,6 +715,10 @@ resource "meraki_appliance_sdwan_internet_policies" "networks_appliance_sdwan_in
   for_each                       = { for v in local.networks_appliance_sdwan_internet_policies : v.key => v }
   network_id                     = each.value.network_id
   wan_traffic_uplink_preferences = each.value.wan_traffic_uplink_preferences
+  depends_on = [
+    meraki_appliance_vlan.networks_appliance_vlans,
+    meraki_appliance_single_lan.networks_appliance_single_lan,
+  ]
 }
 
 locals {


### PR DESCRIPTION
Deletion sometimes fails with:

```
│ Error: Client Error
│
│ Failed to delete object (DELETE), got error: HTTP Request failed: StatusCode 400, {"errors":["The IP address range for traffic filter with src: 192.168.20.0/24 does │ not apply to any configured subnets."]}
╵
```

`networks_appliance_sdwan_internet_policies` uses subnets and vlans, which are configured in `networks_appliance_vlans` and `networks_appliance_single_lan`.
Depend on them to ensure they aren't deleted before `networks_appliance_sdwan_internet_policies`.