### PR TITLE
meraki_appliance: Traffic_shaping & SD WAN Internet Policies Custom Performance Class and Depends On

### DIFF
--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -683,7 +683,7 @@ locals {
               fail_over_criterion            = try(appliance_sdwan_internet_policy.fail_over_criterion, local.defaults.meraki.domains.organizations.networks.appliance.sdwan_internet_policies.fail_over_criterion, null)
               performance_class_type         = try(appliance_sdwan_internet_policy.performance_class.type, local.defaults.meraki.domains.organizations.networks.appliance.sdwan_internet_policies.performance_class.type, null)
               builtin_performance_class_name = try(appliance_sdwan_internet_policy.performance_class.builtin_performance_class_name, local.defaults.meraki.domains.organizations.networks.appliance.sdwan_internet_policies.performance_class.builtin_performance_class_name, null)
-              custom_performance_class_id    = try(appliance_sdwan_internet_policy.performance_class.custom_performance_class_id, local.defaults.meraki.domains.organizations.networks.appliance.sdwan_internet_policies.performance_class.custom_performance_class_id, null)
+              custom_performance_class_id    = try(meraki_appliance_traffic_shaping_custom_performance_class.networks_appliance_traffic_shaping_custom_performance_classes[format("%s/%s/%s/%s", domain.name, organization.name, network.name, appliance_sdwan_internet_policy.performance_class.custom_performance_class_name)].id, null)
               traffic_filters = [
                 for traffic_filter in try(appliance_sdwan_internet_policy.traffic_filters, []) : {
                   type             = try(traffic_filter.type, local.defaults.meraki.domains.organizations.networks.appliance.sdwan_internet_policies.traffic_filters.type, null)

--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -741,6 +741,10 @@ resource "meraki_appliance_traffic_shaping" "networks_appliance_traffic_shaping"
   network_id                  = each.value.network_id
   global_bandwidth_limit_up   = each.value.global_bandwidth_limit_up
   global_bandwidth_limit_down = each.value.global_bandwidth_limit_down
+  depends_on = [
+    meraki_appliance_vlan.networks_appliance_vlans,
+    meraki_appliance_single_lan.networks_appliance_single_lan,
+  ]
 }
 
 locals {
@@ -769,6 +773,10 @@ resource "meraki_appliance_traffic_shaping_custom_performance_class" "networks_a
   max_latency         = each.value.max_latency
   max_jitter          = each.value.max_jitter
   max_loss_percentage = each.value.max_loss_percentage
+  depends_on = [
+    meraki_appliance_vlan.networks_appliance_vlans,
+    meraki_appliance_single_lan.networks_appliance_single_lan,
+  ]
 }
 
 locals {
@@ -805,6 +813,10 @@ resource "meraki_appliance_traffic_shaping_rules" "networks_appliance_traffic_sh
   network_id            = each.value.network_id
   default_rules_enabled = each.value.default_rules_enabled
   rules                 = each.value.rules
+  depends_on = [
+    meraki_appliance_vlan.networks_appliance_vlans,
+    meraki_appliance_single_lan.networks_appliance_single_lan,
+  ]
 }
 
 locals {
@@ -835,6 +847,10 @@ resource "meraki_appliance_traffic_shaping_uplink_bandwidth" "networks_appliance
   wan2_limit_down     = each.value.wan2_limit_down
   cellular_limit_up   = each.value.cellular_limit_up
   cellular_limit_down = each.value.cellular_limit_down
+  depends_on = [
+    meraki_appliance_vlan.networks_appliance_vlans,
+    meraki_appliance_single_lan.networks_appliance_single_lan,
+  ]
 }
 
 locals {
@@ -907,6 +923,11 @@ resource "meraki_appliance_traffic_shaping_uplink_selection" "networks_appliance
   failover_and_failback_immediate_enabled = each.value.failover_and_failback_immediate_enabled
   wan_traffic_uplink_preferences          = each.value.wan_traffic_uplink_preferences
   vpn_traffic_uplink_preferences          = each.value.vpn_traffic_uplink_preferences
+  depends_on = [
+    meraki_appliance_vlan.networks_appliance_vlans,
+    meraki_appliance_single_lan.networks_appliance_single_lan,
+    meraki_appliance_traffic_shaping_custom_performance_class.networks_appliance_traffic_shaping_custom_performance_classes,
+  ]
 }
 
 locals {
@@ -939,6 +960,10 @@ resource "meraki_appliance_traffic_shaping_vpn_exclusions" "networks_appliance_t
   network_id         = each.value.network_id
   custom             = each.value.custom
   major_applications = each.value.major_applications
+  depends_on = [
+    meraki_appliance_vlan.networks_appliance_vlans,
+    meraki_appliance_single_lan.networks_appliance_single_lan,
+  ]
 }
 
 locals {

--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -912,15 +912,7 @@ locals {
               fail_over_criterion            = try(vpn_traffic_uplink_preference.fail_over_criterion, local.defaults.meraki.domains.organizations.networks.appliance.traffic_shaping.uplink_selection.vpn_traffic_uplink_preferences.fail_over_criterion, null)
               performance_class_type         = try(vpn_traffic_uplink_preference.performance_class.type, local.defaults.meraki.domains.organizations.networks.appliance.traffic_shaping.uplink_selection.vpn_traffic_uplink_preferences.performance_class.type, null)
               builtin_performance_class_name = try(vpn_traffic_uplink_preference.performance_class.builtin_performance_class_name, local.defaults.meraki.domains.organizations.networks.appliance.traffic_shaping.uplink_selection.vpn_traffic_uplink_preferences.performance_class.builtin_performance_class_name, null)
-              custom_performance_class_id = try(
-                local.custom_performance_class_ids_by_name[
-                  try(
-                    vpn_traffic_uplink_preference.performance_class.custom_performance_class_name,
-                    local.defaults.meraki.domains.organizations.networks.appliance.traffic_shaping.uplink_selection.vpn_traffic_uplink_preferences.performance_class.custom_performance_class_name
-                  )
-                ],
-                null
-              )
+              custom_performance_class_id = try(meraki_appliance_traffic_shaping_custom_performance_class.networks_appliance_traffic_shaping_custom_performance_classes[format("%s/%s/%s/%s", domain.name, organization.name, network.name, vpn_traffic_uplink_preference.performance_class.custom_performance_class_name)].id, null)
             }
           ]
         } if try(network.appliance.traffic_shaping.uplink_selection, null) != null

--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -854,11 +854,6 @@ resource "meraki_appliance_traffic_shaping_uplink_bandwidth" "networks_appliance
 }
 
 locals {
-  custom_performance_class_ids_by_name = {
-    for k, v in meraki_appliance_traffic_shaping_custom_performance_class.networks_appliance_traffic_shaping_custom_performance_classes :
-    v.name => v.id
-  }
-
   networks_appliance_traffic_shaping_uplink_selection = flatten([
     for domain in try(local.meraki.domains, []) : [
       for organization in try(domain.organizations, []) : [
@@ -912,7 +907,7 @@ locals {
               fail_over_criterion            = try(vpn_traffic_uplink_preference.fail_over_criterion, local.defaults.meraki.domains.organizations.networks.appliance.traffic_shaping.uplink_selection.vpn_traffic_uplink_preferences.fail_over_criterion, null)
               performance_class_type         = try(vpn_traffic_uplink_preference.performance_class.type, local.defaults.meraki.domains.organizations.networks.appliance.traffic_shaping.uplink_selection.vpn_traffic_uplink_preferences.performance_class.type, null)
               builtin_performance_class_name = try(vpn_traffic_uplink_preference.performance_class.builtin_performance_class_name, local.defaults.meraki.domains.organizations.networks.appliance.traffic_shaping.uplink_selection.vpn_traffic_uplink_preferences.performance_class.builtin_performance_class_name, null)
-              custom_performance_class_id = try(meraki_appliance_traffic_shaping_custom_performance_class.networks_appliance_traffic_shaping_custom_performance_classes[format("%s/%s/%s/%s", domain.name, organization.name, network.name, vpn_traffic_uplink_preference.performance_class.custom_performance_class_name)].id, null)
+              custom_performance_class_id    = try(meraki_appliance_traffic_shaping_custom_performance_class.networks_appliance_traffic_shaping_custom_performance_classes[format("%s/%s/%s/%s", domain.name, organization.name, network.name, vpn_traffic_uplink_preference.performance_class.custom_performance_class_name)].id, null)
             }
           ]
         } if try(network.appliance.traffic_shaping.uplink_selection, null) != null


### PR DESCRIPTION
- Add depends on logic to all traffic shaping modules.

    The VLANs and Appliance must be added prior to configuring traffic shaping.

    Having the VLAN applied first ensures that if it is referenced in the rules or definitions it is there prior to applying the rules.

    Explicitly implies that a VLAN or Single VLAN must be configured first (which is a precursor to any Appliance deployment) and assumes the appliance must also have been added. You cannot add a VLAN or Single LAN address without adding an appliance to the inventory.

- Add mapping from `custom_performance_class_name` to ID in:
  - `networks_appliance_traffic_shaping_uplink_selection`;
  - `networks_appliance_sdwan_internet_policies`.