### PR TITLE
meraki_appliance: Adds depends_on logic for Appliance Static Route

### DIFF
--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -668,6 +668,10 @@ resource "meraki_appliance_static_route" "networks_appliance_static_routes" {
   subnet          = each.value.subnet
   gateway_ip      = each.value.gateway_ip
   gateway_vlan_id = each.value.gateway_vlan_id
+  depends_on = [
+    meraki_appliance_vlan.networks_appliance_vlans,
+    meraki_appliance_single_lan.networks_appliance_single_lan,
+  ]
 }
 
 locals {


### PR DESCRIPTION
Add Depends on For Appliance Static Route Resource

Single VLAN or Appliance VLAN must have a valid subnet configured, which appliance static route 'next hop' field depends on and thus must exist and be created prior to adding a static route. Next hop must be within a local network.