### PR TITLE
fix: depends on logic for adaptive policy network settings and device switch ports

### DIFF
--- a/meraki_devices.tf
+++ b/meraki_devices.tf
@@ -245,6 +245,7 @@ resource "meraki_switch_port" "devices_switch_ports" {
   # profile_id                  = try(each.value.data.profile.id, local.defaults.meraki.domains.organizations.networks.devices.switch.ports.profile.id, null)
   profile_iname  = try(each.value.data.profile.iname, local.defaults.meraki.domains.organizations.networks.devices.switch.ports.profile.iname, null)
   dot3az_enabled = try(each.value.data.dot3az, local.defaults.meraki.domains.organizations.networks.devices.switch.ports.dot3az, null)
+  depends_on     = [meraki_organization_adaptive_policy_settings.organizations_adaptive_policy_settings_enabled_networks]
 }
 
 locals {

--- a/meraki_organization.tf
+++ b/meraki_organization.tf
@@ -236,7 +236,7 @@ resource "meraki_organization_adaptive_policy_settings" "organizations_adaptive_
   for_each         = { for v in local.organizations_adaptive_policy_settings_enabled_networks : v.key => v }
   organization_id  = each.value.organization_id
   enabled_networks = each.value.enabled_networks
-  depends_on       = [meraki_network.organizations_networks]
+  depends_on       = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {


### PR DESCRIPTION
+ Device Switch Ports fail to apply occasionally if Adaptive Policy is not enabled on a network.

    A dependancy needs to be tracked by terraform for meraki_organization_adaptive_policy_settings.organizations_adaptive_policy_settings_enabled_networks to ensure it has been applied to the built network prior to enabling adaptive policy onto the switch port.

+ Adaptive Policy Networks fails to apply occasionally if a network does not contain SD WAN appliances with the correct licenses. Adding device claim to this dependancy ensures that a device must of been added to the network previously.

    Obviously this assumes the user has added their own licensing.

+ Remove Adaptive Policy Enabled Networks explicit dependency on networks - it already depends on the individual networks it references.