### PR TITLE
meraki_appliance: Restore networks_appliance_ports depends_on

### DIFF
--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -310,6 +310,11 @@ resource "meraki_appliance_ports" "networks_appliance_ports" {
       }
     ]
   ])
+  depends_on = [
+    meraki_network_device_claim.networks_devices_claim,
+    meraki_appliance_vlan.networks_appliance_vlans,
+    meraki_appliance_single_lan.networks_appliance_single_lan,
+  ]
 }
 
 locals {


### PR DESCRIPTION
`terraform apply` fails for `networks_appliance_ports` on the first run, but succeeds on a subsequent run, with one of the following errors:

First:

```
  # module.meraki.meraki_appliance_ports.networks_appliance_ports["EMEA/Dev-WB/netascode-network-01"] will be created
  + resource "meraki_appliance_ports" "networks_appliance_ports" {
      + id              = (known after apply)
      + items           = [
          + {
              + access_policy = "open"
              + enabled       = true
              + port_id       = "6"
              + type          = "access"
              + vlan          = 10
            },
          + {
              + allowed_vlans = "1,10,20"
              + enabled       = true
              + port_id       = "3"
              + type          = "trunk"
            },
          + {
              + allowed_vlans = "1,10,20"
              + enabled       = true
              + port_id       = "4"
              + type          = "trunk"
            },
          + {
              + allowed_vlans = "1,10,20"
              + enabled       = true
              + port_id       = "5"
              + type          = "trunk"
            },
        ]
      + network_id      = (known after apply)
      + organization_id = "1685205"
    }

<...>

│ Error: Client Error
│
│   with module.meraki.meraki_appliance_ports.networks_appliance_ports["EMEA/Dev-WB/netascode-network-01"],
│   on ../../../../../../terraform-meraki-nac-meraki/meraki_appliance.tf line 296, in resource "meraki_appliance_ports" "networks_appliance_ports":
│  296: resource "meraki_appliance_ports" "networks_appliance_ports" {
│
│ Failed to configure objects (Action Batch), got error: Batch request failed: ["Error occurred while executing update
│ /networks/L_4005951868546058076/appliance/ports/6 with {\"accessPolicy\":\"open\",\"enabled\":true,\"type\":\"access\",\"vlan\":10}"],
│ {"id":"4005951868546056371","organizationId":"1685205","confirmed":true,"synchronous":true,"status":{"completed":false,"failed":true,"errors":["Error occurred
│ while executing update /networks/L_4005951868546058076/appliance/ports/6 with
│ {\"accessPolicy\":\"open\",\"enabled\":true,\"type\":\"access\",\"vlan\":10}"],"createdResources":[]},"actions":[{"resource":"/networks/L_4005951868546058076/appliance/ports/6","operation":"update","body":{"accessPolicy":"open","enabled":true,"type":"access","vlan":10}},{"resource":"/networks/L_4005951868546058076/appliance/ports/3","operation":"update","body":{"allowedVlans":"1,10,20","enabled":true,"type":"trunk"}},{"resource":"/networks/L_4005951868546058076/appliance/ports/4","operation":"update","body":{"allowedVlans":"1,10,20","enabled":true,"type":"trunk"}},{"resource":"/networks/L_4005951868546058076/appliance/ports/5","operation":"update","body":{"allowedVlans":"1,10,20","enabled":true,"type":"trunk"}}]}
```

Second:

```
│ Error: Client Error
│
│   with module.meraki.meraki_appliance_ports.networks_appliance_ports["EMEA/Dev-WB/netascode-network-01"],
│   on ../../../../../../terraform-meraki-nac-meraki/meraki_appliance.tf line 296, in resource "meraki_appliance_ports" "networks_appliance_ports":
│  296: resource "meraki_appliance_ports" "networks_appliance_ports" {
│
│ Failed to configure objects (Action Batch), got error: Batch request failed: ["A valid VLAN is required"],
│ {"id":"4005951868546056383","organizationId":"1685205","confirmed":true,"synchronous":true,"status":{"completed":false,"failed":true,"errors":["A valid VLAN is
│ required"],"createdResources":[]},"actions":[{"resource":"/networks/L_4005951868546058561/appliance/ports/6","operation":"update","body":{"accessPolicy":"open","enabled":true,"type":"access","vlan":10}},{"resource":"/networks/L_4005951868546058561/appliance/ports/3","operation":"update","body":{"allowedVlans":"1,10,20","enabled":true,"type":"trunk"}},{"resource":"/networks/L_4005951868546058561/appliance/ports/4","operation":"update","body":{"allowedVlans":"1,10,20","enabled":true,"type":"trunk"}},{"resource":"/networks/L_4005951868546058561/appliance/ports/5","operation":"update","body":{"allowedVlans":"1,10,20","enabled":true,"type":"trunk"}}]}
```

Restoring the `depends_on` missed/removed when adding range support (in https://github.com/netascode/terraform-meraki-nac-meraki/pull/78/files#diff-649a645aa2b59f9def97a9c3ba97df93fa2e802fa35a94328d993e7f35a94ac5L306) fixes the issue.