### PR TITLE
revert: drop device-claim batching (PR #92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ module "meraki" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_meraki"></a> [meraki](#requirement\_meraki) | >= 1.5.0 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.0 |
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -76,8 +75,8 @@ module "meraki" {
 | [meraki_appliance_one_to_many_nat_rules.networks_appliance_firewall_one_to_many_nat_rules](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/appliance_one_to_many_nat_rules) | resource |
 | [meraki_appliance_one_to_one_nat_rules.networks_appliance_firewall_one_to_one_nat_rules](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/appliance_one_to_one_nat_rules) | resource |
 | [meraki_appliance_organization_security_intrusion.organizations_appliance_security_intrusion_allowed_rules](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/appliance_organization_security_intrusion) | resource |
+| [meraki_appliance_port.networks_appliance_ports](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/appliance_port) | resource |
 | [meraki_appliance_port_forwarding_rules.networks_appliance_firewall_port_forwarding_rules](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/appliance_port_forwarding_rules) | resource |
-| [meraki_appliance_ports.networks_appliance_ports](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/appliance_ports) | resource |
 | [meraki_appliance_radio_settings.devices_appliance_radio_settings](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/appliance_radio_settings) | resource |
 | [meraki_appliance_rf_profile.networks_appliance_rf_profiles](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/appliance_rf_profile) | resource |
 | [meraki_appliance_sdwan_internet_policies.networks_appliance_sdwan_internet_policies](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/appliance_sdwan_internet_policies) | resource |
@@ -112,7 +111,6 @@ module "meraki" {
 | [meraki_device_management_interface.devices_management_interface](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/device_management_interface) | resource |
 | [meraki_network.organizations_networks](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network) | resource |
 | [meraki_network_device_claim.networks_devices_claim](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_device_claim) | resource |
-| [meraki_network_device_claim.networks_devices_claim_batch_delayed](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_device_claim) | resource |
 | [meraki_network_floor_plan.networks_floor_plans](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_floor_plan) | resource |
 | [meraki_network_group_policy.networks_group_policies](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_group_policy) | resource |
 | [meraki_network_settings.networks_settings](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_settings) | resource |
@@ -173,7 +171,6 @@ module "meraki" {
 | [meraki_wireless_ssid_schedules.networks_wireless_ssids_schedules](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/wireless_ssid_schedules) | resource |
 | [meraki_wireless_ssid_splash_settings.networks_wireless_ssids_splash_settings](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/wireless_ssid_splash_settings) | resource |
 | [meraki_wireless_ssid_traffic_shaping_rules.networks_wireless_ssids_traffic_shaping_rules](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/wireless_ssid_traffic_shaping_rules) | resource |
-| [time_sleep.device_claim_delay](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [meraki_organization.organizations](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/data-sources/organization) | data source |
 ## Modules
 

--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -22,7 +22,7 @@ resource "meraki_appliance_content_filtering" "networks_appliance_content_filter
   blocked_url_patterns   = each.value.blocked_url_patterns
   blocked_url_categories = each.value.blocked_url_categories
   url_category_list_size = each.value.url_category_list_size
-  depends_on             = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on             = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -49,7 +49,7 @@ resource "meraki_appliance_firewalled_service" "networks_appliance_firewall_fire
   access      = each.value.access
   allowed_ips = each.value.allowed_ips
   service     = each.value.service
-  depends_on  = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on  = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -83,7 +83,7 @@ resource "meraki_appliance_inbound_firewall_rules" "networks_appliance_firewall_
   network_id          = each.value.network_id
   rules               = each.value.rules
   syslog_default_rule = each.value.syslog_default_rule
-  depends_on          = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on          = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -117,7 +117,7 @@ resource "meraki_appliance_l3_firewall_rules" "networks_appliance_firewall_l3_fi
   network_id          = each.value.network_id
   syslog_default_rule = each.value.syslog_default_rule
   rules               = each.value.rules
-  depends_on          = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on          = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -145,7 +145,7 @@ resource "meraki_appliance_l7_firewall_rules" "networks_appliance_firewall_l7_fi
   for_each   = { for v in local.networks_appliance_firewall_l7_firewall_rules : v.key => v }
   network_id = each.value.network_id
   rules      = each.value.rules
-  depends_on = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -181,7 +181,7 @@ resource "meraki_appliance_one_to_many_nat_rules" "networks_appliance_firewall_o
   for_each   = { for v in local.networks_appliance_firewall_one_to_many_nat_rules : v.key => v }
   network_id = each.value.network_id
   rules      = each.value.rules
-  depends_on = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -216,7 +216,7 @@ resource "meraki_appliance_one_to_one_nat_rules" "networks_appliance_firewall_on
   for_each   = { for v in local.networks_appliance_firewall_one_to_one_nat_rules : v.key => v }
   network_id = each.value.network_id
   rules      = each.value.rules
-  depends_on = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -247,7 +247,7 @@ resource "meraki_appliance_port_forwarding_rules" "networks_appliance_firewall_p
   for_each   = { for v in local.networks_appliance_firewall_port_forwarding_rules : v.key => v }
   network_id = each.value.network_id
   rules      = each.value.rules
-  depends_on = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -268,7 +268,7 @@ resource "meraki_appliance_firewall_settings" "networks_appliance_firewall_setti
   for_each                                 = { for v in local.networks_appliance_firewall_settings_spoofing_protection_ip_source_guard_mode : v.key => v }
   network_id                               = each.value.network_id
   spoofing_protection_ip_source_guard_mode = each.value.spoofing_protection_ip_source_guard_mode
-  depends_on                               = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on                               = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -293,29 +293,17 @@ locals {
   ])
 }
 
-resource "meraki_appliance_ports" "networks_appliance_ports" {
-  for_each        = { for v in local.networks_appliance_ports : v.key => v }
-  organization_id = each.value.organization_id
-  network_id      = each.value.network_id
-  items = flatten([
-    for ports in each.value.ports : [
-      for port_id in ports.port_ids : {
-        port_id               = port_id
-        enabled               = try(ports.data.enabled, local.defaults.meraki.domains.organizations.networks.appliance_ports.enabled, null)
-        drop_untagged_traffic = try(ports.data.drop_untagged_traffic, local.defaults.meraki.domains.organizations.networks.appliance_ports.drop_untagged_traffic, null)
-        type                  = try(ports.data.type, local.defaults.meraki.domains.organizations.networks.appliance_ports.type, null)
-        vlan                  = try(ports.data.vlan, local.defaults.meraki.domains.organizations.networks.appliance_ports.vlan, null)
-        allowed_vlans         = try(ports.data.allowed_vlans, local.defaults.meraki.domains.organizations.networks.appliance_ports.allowed_vlans, null)
-        access_policy         = try(ports.data.access_policy, local.defaults.meraki.domains.organizations.networks.appliance_ports.access_policy, null)
-      }
-    ]
-  ])
-  depends_on = [
-    meraki_network_device_claim.networks_devices_claim,
-    meraki_network_device_claim.networks_devices_claim_batch_delayed,
-    meraki_appliance_vlan.networks_appliance_vlans,
-    meraki_appliance_single_lan.networks_appliance_single_lan,
-  ]
+resource "meraki_appliance_port" "networks_appliance_ports" {
+  for_each              = { for v in local.networks_appliance_ports : v.key => v }
+  network_id            = each.value.network_id
+  enabled               = each.value.enabled
+  drop_untagged_traffic = each.value.drop_untagged_traffic
+  type                  = each.value.type
+  vlan                  = each.value.vlan
+  allowed_vlans         = each.value.allowed_vlans
+  access_policy         = each.value.access_policy
+  port_id               = each.value.port_id
+  depends_on            = [meraki_network_device_claim.networks_devices_claim, meraki_appliance_vlan.networks_appliance_vlans, meraki_appliance_single_lan.networks_appliance_single_lan]
 }
 
 locals {
@@ -344,7 +332,7 @@ resource "meraki_appliance_network_security_intrusion" "networks_appliance_secur
   protected_networks_use_default   = each.value.protected_networks_use_default
   protected_networks_included_cidr = each.value.protected_networks_included_cidr
   protected_networks_excluded_cidr = each.value.protected_networks_excluded_cidr
-  depends_on                       = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on                       = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -379,7 +367,7 @@ resource "meraki_appliance_security_malware" "networks_appliance_security_malwar
   mode          = each.value.mode
   allowed_urls  = each.value.allowed_urls
   allowed_files = each.value.allowed_files
-  depends_on    = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on    = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -406,7 +394,7 @@ resource "meraki_appliance_settings" "networks_appliance_settings" {
   deployment_mode        = each.value.deployment_mode
   dynamic_dns_prefix     = each.value.dynamic_dns_prefix
   dynamic_dns_enabled    = each.value.dynamic_dns_enabled
-  depends_on             = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on             = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -443,7 +431,7 @@ resource "meraki_appliance_single_lan" "networks_appliance_single_lan" {
   ipv6_enabled            = each.value.ipv6_enabled
   ipv6_prefix_assignments = each.value.ipv6_prefix_assignments
   mandatory_dhcp_enabled  = each.value.mandatory_dhcp_enabled
-  depends_on              = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on              = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -548,7 +536,7 @@ resource "meraki_appliance_vlans_settings" "networks_appliance_vlans_settings" {
   for_each      = { for v in local.networks_appliance_vlans_settings : v.key => v }
   network_id    = each.value.network_id
   vlans_enabled = each.value.vlans_enabled
-  depends_on    = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on    = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -628,7 +616,7 @@ resource "meraki_appliance_site_to_site_vpn" "networks_appliance_vpn_site_to_sit
   hubs                  = each.value.hubs
   subnets               = each.value.subnets
   subnet_nat_is_allowed = each.value.subnet_nat_is_allowed
-  depends_on            = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed, meraki_appliance_single_lan.networks_appliance_single_lan, meraki_appliance_vlan.networks_appliance_vlans]
+  depends_on            = [meraki_network_device_claim.networks_devices_claim, meraki_appliance_single_lan.networks_appliance_single_lan, meraki_appliance_vlan.networks_appliance_vlans]
 }
 
 locals {
@@ -657,7 +645,7 @@ resource "meraki_appliance_warm_spare" "networks_appliance_warm_spare" {
   uplink_mode  = each.value.uplink_mode
   virtual_ip1  = each.value.virtual_ip1
   virtual_ip2  = each.value.virtual_ip2
-  depends_on   = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on   = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -1039,7 +1027,7 @@ resource "meraki_appliance_ssid" "networks_appliance_ssids" {
   dhcp_enforced_deauthentication_enabled = each.value.dhcp_enforced_deauthentication_enabled
   dot11w_enabled                         = each.value.dot11w_enabled
   dot11w_required                        = each.value.dot11w_required
-  depends_on                             = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on                             = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -1102,7 +1090,7 @@ resource "meraki_appliance_rf_profile" "networks_appliance_rf_profiles" {
   per_ssid_settings_3_band_steering_enabled = try(each.value.per_ssid_settings[2].band_steering_enabled, null)
   per_ssid_settings_4_band_operation_mode   = try(each.value.per_ssid_settings[3].band_operation_mode, null)
   per_ssid_settings_4_band_steering_enabled = try(each.value.per_ssid_settings[3].band_steering_enabled, null)
-  depends_on                                = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on                                = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {

--- a/meraki_devices.tf
+++ b/meraki_devices.tf
@@ -34,10 +34,7 @@ resource "meraki_device" "devices" {
   move_map_marker = each.value.move_map_marker
   #switch_profile_id = each.value.switch_profile_id
   floor_plan_id = each.value.floor_plan_id
-  depends_on = [
-    meraki_network_device_claim.networks_devices_claim,
-    meraki_network_device_claim.networks_devices_claim_batch_delayed
-  ]
+  depends_on    = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -265,63 +265,20 @@ locals {
   networks_devices_claim = flatten([
     for domain in try(local.meraki.domains, []) : [
       for organization in try(domain.organizations, []) : [
-        for network in try(organization.networks, []) :
-        try(local.defaults.meraki.domains.organizations.networks.devices_claim_rate_limiting.enabled, false) == true ? (
-          try(network.devices, null) != null ? [
-            for batch_index in range(0, length([for d in network.devices : d.serial]), try(local.defaults.meraki.domains.organizations.networks.devices_claim_rate_limiting.count, 10)) : {
-              key          = batch_index > 0 ? format("%s/%s/%s/batch_%d", domain.name, organization.name, network.name, batch_index / try(local.defaults.meraki.domains.organizations.networks.devices_claim_rate_limiting.count, 10)) : format("%s/%s/%s", domain.name, organization.name, network.name)
-              network_id   = meraki_network.organizations_networks[format("%s/%s/%s", domain.name, organization.name, network.name)].id
-              serials      = slice([for d in network.devices : d.serial], batch_index, min(batch_index + try(local.defaults.meraki.domains.organizations.networks.devices_claim_rate_limiting.count, 10), length([for d in network.devices : d.serial])))
-              batch_number = batch_index / try(local.defaults.meraki.domains.organizations.networks.devices_claim_rate_limiting.count, 10)
-            }
-          ] : []
-          ) : (
-          try(network.devices, null) != null ? [{
-            key          = format("%s/%s/%s", domain.name, organization.name, network.name)
-            network_id   = meraki_network.organizations_networks[format("%s/%s/%s", domain.name, organization.name, network.name)].id
-            serials      = [for d in network.devices : d.serial]
-            batch_number = 0
-          }] : []
-        )
+        for network in try(organization.networks, []) : {
+          key        = format("%s/%s/%s", domain.name, organization.name, network.name)
+          network_id = meraki_network.organizations_networks[format("%s/%s/%s", domain.name, organization.name, network.name)].id
+          serials    = [for d in network.devices : d.serial]
+        } if try(network.devices, null) != null
       ]
     ]
   ])
 }
 
-resource "time_sleep" "device_claim_delay" {
-  for_each = {
-    for v in local.networks_devices_claim : v.key => v
-    if v.batch_number > 0
-  }
-
-  create_duration = try("${tostring(local.defaults.meraki.domains.organizations.networks.devices_claim_rate_limiting.interval)}s", "300s")
-}
-
-# First batch executes immediately
 resource "meraki_network_device_claim" "networks_devices_claim" {
-  for_each = {
-    for v in local.networks_devices_claim : v.key => v
-    if v.batch_number == 0
-  }
-
+  for_each   = { for v in local.networks_devices_claim : v.key => v }
   network_id = each.value.network_id
   serials    = each.value.serials
-}
-
-# Subsequent batches wait for delays
-resource "meraki_network_device_claim" "networks_devices_claim_batch_delayed" {
-  for_each = {
-    for v in local.networks_devices_claim : v.key => v
-    if v.batch_number > 0
-  }
-
-  network_id = each.value.network_id
-  serials    = each.value.serials
-
-  depends_on = [
-    time_sleep.device_claim_delay,
-    meraki_network_device_claim.networks_devices_claim
-  ]
 }
 
 locals {

--- a/meraki_organization.tf
+++ b/meraki_organization.tf
@@ -236,7 +236,7 @@ resource "meraki_organization_adaptive_policy_settings" "organizations_adaptive_
   for_each         = { for v in local.organizations_adaptive_policy_settings_enabled_networks : v.key => v }
   organization_id  = each.value.organization_id
   enabled_networks = each.value.enabled_networks
-  depends_on       = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on       = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {

--- a/meraki_switches.tf
+++ b/meraki_switches.tf
@@ -223,7 +223,7 @@ resource "meraki_switch_dscp_to_cos_mappings" "networks_switch_dscp_to_cos_mappi
   for_each   = { for v in local.networks_switch_dscp_to_cos_mappings : v.key => v }
   network_id = each.value.network_id
   mappings   = each.value.mappings
-  depends_on = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on = [meraki_network_device_claim.networks_devices_claim]
 }
 
 
@@ -289,7 +289,7 @@ resource "meraki_switch_mtu" "networks_switch_mtu" {
   network_id       = each.value.network_id
   default_mtu_size = each.value.default_mtu_size
   overrides        = each.value.overrides
-  depends_on       = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on       = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -354,7 +354,7 @@ resource "meraki_switch_port_schedule" "networks_switch_port_schedules" {
   port_schedule_sunday_active    = each.value.port_schedule_sunday_active
   port_schedule_sunday_from      = each.value.port_schedule_sunday_from
   port_schedule_sunday_to        = each.value.port_schedule_sunday_to
-  depends_on                     = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on                     = [meraki_network_device_claim.networks_devices_claim]
 }
 
 
@@ -390,7 +390,7 @@ resource "meraki_switch_qos_rule" "networks_switch_qos_rules" {
   dst_port       = each.value.dst_port
   dst_port_range = each.value.dst_port_range
   dscp           = each.value.dscp
-  depends_on     = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on     = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -445,7 +445,7 @@ resource "meraki_switch_routing_multicast" "networks_switch_routing_multicast" {
   default_settings_igmp_snooping_enabled                   = each.value.default_settings_igmp_snooping_enabled
   default_settings_flood_unknown_multicast_traffic_enabled = each.value.default_settings_flood_unknown_multicast_traffic_enabled
   overrides                                                = each.value.overrides
-  depends_on                                               = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on                                               = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -523,10 +523,7 @@ resource "meraki_switch_routing_ospf" "networks_switch_routing_ospf" {
   md5_authentication_enabled        = each.value.md5_authentication_enabled
   md5_authentication_key_id         = each.value.md5_authentication_key_id
   md5_authentication_key_passphrase = each.value.md5_authentication_key_passphrase
-  depends_on = [
-    meraki_network_device_claim.networks_devices_claim,
-    meraki_network_device_claim.networks_devices_claim_batch_delayed
-  ]
+  depends_on                        = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -560,7 +557,7 @@ resource "meraki_switch_settings" "networks_switch_settings" {
   power_exceptions               = each.value.power_exceptions
   uplink_client_sampling_enabled = each.value.uplink_client_sampling_enabled
   mac_blocklist_enabled          = each.value.mac_blocklist_enabled
-  depends_on                     = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on                     = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -587,10 +584,7 @@ resource "meraki_switch_storm_control" "networks_switch_storm_control" {
   multicast_threshold                        = each.value.multicast_threshold
   unknown_unicast_threshold                  = each.value.unknown_unicast_threshold
   treat_these_traffic_types_as_one_threshold = each.value.treat_these_traffic_types_as_one_threshold
-  depends_on = [
-    meraki_network_device_claim.networks_devices_claim,
-    meraki_network_device_claim.networks_devices_claim_batch_delayed
-  ]
+  depends_on                                 = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -624,10 +618,7 @@ resource "meraki_switch_stp" "networks_switch_stp" {
   network_id          = each.value.network_id
   rstp_enabled        = each.value.rstp_enabled
   stp_bridge_priority = each.value.stp_bridge_priority
-  depends_on = [
-    meraki_network_device_claim.networks_devices_claim,
-    meraki_network_device_claim.networks_devices_claim_batch_delayed
-  ]
+  depends_on          = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -652,7 +643,7 @@ resource "meraki_switch_stack" "networks_switch_stacks" {
   network_id = each.value.network_id
   name       = each.value.name
   serials    = each.value.serials
-  depends_on = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {
@@ -713,7 +704,7 @@ resource "meraki_switch_stack_routing_interface" "networks_switch_stacks_routing
   ipv6_prefix                      = each.value.ipv6_prefix
   ipv6_address                     = each.value.ipv6_address
   ipv6_gateway                     = each.value.ipv6_gateway
-  depends_on                       = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on                       = [meraki_network_device_claim.networks_devices_claim]
 }
 resource "meraki_switch_stack_routing_interface" "networks_switch_stacks_routing_interfaces_not_first" {
   for_each                         = { for i in local.networks_switch_stacks_routing_interfaces_not_first : i.key => i }

--- a/versions.tf
+++ b/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "CiscoDevNet/meraki"
       version = ">= 1.5.0"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = ">= 0.9.0"
-    }
   }
 }


### PR DESCRIPTION
We have discovered that:
- An additional issue appeared that this workaround cannot deal with: `"Timeout reached. Please try again with fewer devices or contact support"` has started happening in the pipeline for the 0th batch on a brand-new network (which has no delay and should not require one if the documentation (10 devices per 5 minutes per network) is to be believed).
- That issue, along with the rate limit being worked around, only happens on the shard the pipeline is using, and not on 3 other shards we tested.

We decided to work with Meraki support on the issue with that shard instead and use other shards in the meantime, since it is not documented sufficiently for a proper workaround.