### PR TITLE
#1593 | Appliance Firewall Rules | add dependency for vlans

### DIFF
--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -83,7 +83,7 @@ resource "meraki_appliance_inbound_firewall_rules" "networks_appliance_firewall_
   network_id          = each.value.network_id
   rules               = each.value.rules
   syslog_default_rule = each.value.syslog_default_rule
-  depends_on          = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on          = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed, meraki_appliance_vlan.networks_appliance_vlans]
 }
 
 locals {

--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -117,7 +117,7 @@ resource "meraki_appliance_l3_firewall_rules" "networks_appliance_firewall_l3_fi
   network_id          = each.value.network_id
   syslog_default_rule = each.value.syslog_default_rule
   rules               = each.value.rules
-  depends_on          = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed]
+  depends_on          = [meraki_network_device_claim.networks_devices_claim, meraki_network_device_claim.networks_devices_claim_batch_delayed, meraki_appliance_vlan.networks_appliance_vlans]
 }
 
 locals {


### PR DESCRIPTION
Addressing the situation where the L3 Firewall rules would fail, when the VLAN it refers in rules are still being created or not yet created.

the fix is to make VLANS a dependency of L3 Firewall rules.

╷
│ Error: Client Error
│ 
│   with module.meraki.meraki_appliance_l3_firewall_rules.networks_appliance_firewall_l3_firewall_rules["EMEA/XXXX/BRANCH - Melbourne"],
│   on .terraform/modules/meraki/meraki_appliance.tf line 115, in resource "meraki_appliance_l3_firewall_rules" "networks_appliance_firewall_l3_firewall_rules":
│  115: resource "meraki_appliance_l3_firewall_rules" "networks_appliance_firewall_l3_firewall_rules" {
│ 
│ Failed to configure object (PUT), got error: HTTP Request failed: StatusCode 400, JSON error: ["At least one of your firewall rules is invalid:
│ \"network[firewall_rules][2][srcCidr] No VLANs found with VLAN ID 12\", \"network[firewall_rules][2][destCidr] No VLANs found with VLAN ID 11\",
│ \"network[firewall_rules][3][srcCidr] No VLANs found with VLAN ID 13\", \"network[firewall_rules][3][destCidr] No VLANs found with VLAN ID 11\",
│ \"network[firewall_rules][4][srcCidr] No VLANs found with VLAN ID 13\", \"network[firewall_rules][4][destCidr] No VLANs found with VLAN ID 12\"."], {"errors":["At
│ least one of your firewall rules is invalid: \"network[firewall_rules][2][srcCidr] No VLANs found with VLAN ID 12\", \"network[firewall_rules][2][destCidr] No
│ VLANs found with VLAN ID 11\", \"network[firewall_rules][3][srcCidr] No VLANs found with VLAN ID 13\", \"network[firewall_rules][3][destCidr] No VLANs found with
│ VLAN ID 11\", \"network[firewall_rules][4][srcCidr] No VLANs found with VLAN ID 13\", \"network[firewall_rules][4][destCidr] No VLANs found with VLAN ID 12\"."]}