### PR TITLE
networks_appliance_vlans: Add ipv6_prefix_assignments[].disabled

### DIFF
--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -460,6 +460,7 @@ locals {
             ipv6_prefix_assignments = try(length(appliance_vlan.ipv6.prefix_assignments) == 0, true) ? null : [
               for ipv6_prefix_assignment in try(appliance_vlan.ipv6.prefix_assignments, []) : {
                 autonomous           = try(ipv6_prefix_assignment.autonomous, local.defaults.meraki.domains.organizations.networks.appliance.vlans.ipv6.prefix_assignments.autonomous, null)
+                disabled             = try(ipv6_prefix_assignment.disabled, local.defaults.meraki.domains.organizations.networks.appliance.vlans.ipv6.prefix_assignments.disabled, null)
                 static_prefix        = try(ipv6_prefix_assignment.static_prefix, local.defaults.meraki.domains.organizations.networks.appliance.vlans.ipv6.prefix_assignments.static_prefix, null)
                 static_appliance_ip6 = try(ipv6_prefix_assignment.static_appliance_ip6, local.defaults.meraki.domains.organizations.networks.appliance.vlans.ipv6.prefix_assignments.static_appliance_ip6, null)
                 origin_type          = try(ipv6_prefix_assignment.origin.type, local.defaults.meraki.domains.organizations.networks.appliance.vlans.ipv6.prefix_assignments.origin.type, null)


### PR DESCRIPTION
Issue https://github.com/CiscoDevNet/terraform-provider-meraki/issues/121

Depends on https://github.com/CiscoDevNet/terraform-provider-meraki/pull/125

Based on (and includes) #115 - rebase and merge after that is merged.