### PR TITLE
Fix 1784 | meraki_wireless_rf_profile | add 2 new parameters for RF profile default handling

### DIFF
--- a/meraki_wireless.tf
+++ b/meraki_wireless.tf
@@ -64,6 +64,8 @@ locals {
                 bands = try(by_model.bands, local.defaults.meraki.domains.organizations.networks.wireless.rf_profiles.flex_radios.bands, null)
               }
             ]
+            is_indoor_default  = try(wireless_rf_profile.is_indoor_default, local.defaults.meraki.domains.organizations.networks.wireless.rf_profiles.is_indoor_default, null)
+            is_outdoor_default = try(wireless_rf_profile.is_outdoor_default, local.defaults.meraki.domains.organizations.networks.wireless.rf_profiles.is_outdoor_default, null)
           }
         ]
       ]
@@ -161,6 +163,8 @@ resource "meraki_wireless_rf_profile" "networks_wireless_rf_profiles" {
   per_ssid_settings_14_bands_enabled         = try(each.value.per_ssid_settings[14].bands, null)
   per_ssid_settings_14_band_steering_enabled = try(each.value.per_ssid_settings[14].band_steering_enabled, null)
   flex_radios_by_model                       = each.value.flex_radios_by_model
+  is_indoor_default                          = each.value.is_indoor_default
+  is_outdoor_default                         = each.value.is_outdoor_default
 }
 
 locals {


### PR DESCRIPTION
added `is_indoor_default` and `is_outdoor_default`