### PR TITLE
Allow specifying empty lists of maps explicitly

### DIFF
--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -63,7 +63,7 @@ locals {
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-          rules = try(length(network.appliance.firewall.inbound_firewall_rules.rules) == 0, true) ? null : [
+          rules = try(network.appliance.firewall.inbound_firewall_rules.rules, null) == null ? null : [
             for rule in try(network.appliance.firewall.inbound_firewall_rules.rules, []) : {
               comment        = try(rule.comment, local.defaults.meraki.domains.organizations.networks.appliance.firewall.inbound_firewall_rules.rules.comment, null)
               policy         = try(rule.policy, local.defaults.meraki.domains.organizations.networks.appliance.firewall.inbound_firewall_rules.rules.policy, null)
@@ -137,7 +137,7 @@ locals {
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-          rules = try(length(network.appliance.firewall.l7_firewall_rules) == 0, true) ? null : [
+          rules = try(network.appliance.firewall.l7_firewall_rules, null) == null ? null : [
             for appliance_firewall_l7_firewall_rule in try(network.appliance.firewall.l7_firewall_rules, []) : {
               policy          = try(appliance_firewall_l7_firewall_rule.policy, local.defaults.meraki.domains.organizations.networks.appliance.firewall.l7_firewall_rules.policy, null)
               type            = try(appliance_firewall_l7_firewall_rule.type, local.defaults.meraki.domains.organizations.networks.appliance.firewall.l7_firewall_rules.type, null)
@@ -167,11 +167,11 @@ locals {
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-          rules = try(length(network.appliance.firewall.one_to_many_nat_rules) == 0, true) ? null : [
+          rules = try(network.appliance.firewall.one_to_many_nat_rules, null) == null ? null : [
             for appliance_firewall_one_to_many_nat_rule in try(network.appliance.firewall.one_to_many_nat_rules, []) : {
               public_ip = try(appliance_firewall_one_to_many_nat_rule.public_ip, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_many_nat_rules.public_ip, null)
               uplink    = try(appliance_firewall_one_to_many_nat_rule.uplink, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_many_nat_rules.uplink, null)
-              port_rules = try(length(appliance_firewall_one_to_many_nat_rule.port_rules) == 0, true) ? null : [
+              port_rules = try(appliance_firewall_one_to_many_nat_rule.port_rules, null) == null ? null : [
                 for port_rule in try(appliance_firewall_one_to_many_nat_rule.port_rules, []) : {
                   name        = try(port_rule.name, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_many_nat_rules.port_rules.name, null)
                   protocol    = try(port_rule.protocol, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_many_nat_rules.port_rules.protocol, null)
@@ -205,13 +205,13 @@ locals {
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-          rules = try(length(network.appliance.firewall.one_to_one_nat_rules) == 0, true) ? null : [
+          rules = try(network.appliance.firewall.one_to_one_nat_rules, null) == null ? null : [
             for appliance_firewall_one_to_one_nat_rule in try(network.appliance.firewall.one_to_one_nat_rules, []) : {
               name      = try(appliance_firewall_one_to_one_nat_rule.name, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_one_nat_rules.name, null)
               public_ip = try(appliance_firewall_one_to_one_nat_rule.public_ip, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_one_nat_rules.public_ip, null)
               lan_ip    = try(appliance_firewall_one_to_one_nat_rule.lan_ip, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_one_nat_rules.lan_ip, null)
               uplink    = try(appliance_firewall_one_to_one_nat_rule.uplink, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_one_nat_rules.uplink, null)
-              allowed_inbound = try(length(appliance_firewall_one_to_one_nat_rule.allowed_inbound) == 0, true) ? null : [
+              allowed_inbound = try(appliance_firewall_one_to_one_nat_rule.allowed_inbound, null) == null ? null : [
                 for allowed_inbound in try(appliance_firewall_one_to_one_nat_rule.allowed_inbound, []) : {
                   protocol          = try(allowed_inbound.protocol, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_one_nat_rules.allowed_inbound.protocol, null)
                   destination_ports = try(allowed_inbound.destination_ports, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_one_nat_rules.allowed_inbound.destination_ports, null)
@@ -242,7 +242,7 @@ locals {
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-          rules = try(length(network.appliance.firewall.port_forwarding_rules) == 0, true) ? null : [
+          rules = try(network.appliance.firewall.port_forwarding_rules, null) == null ? null : [
             for appliance_firewall_port_forwarding_rule in try(network.appliance.firewall.port_forwarding_rules, []) : {
               name        = try(appliance_firewall_port_forwarding_rule.name, local.defaults.meraki.domains.organizations.networks.appliance.firewall.port_forwarding_rules.name, null)
               lan_ip      = try(appliance_firewall_port_forwarding_rule.lan_ip, local.defaults.meraki.domains.organizations.networks.appliance.firewall.port_forwarding_rules.lan_ip, null)
@@ -376,13 +376,13 @@ locals {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
           mode       = try(network.appliance.security_malware.mode, local.defaults.meraki.domains.organizations.networks.appliance.security_malware.mode, null)
-          allowed_urls = try(length(network.appliance.security_malware.allowed_urls) == 0, true) ? null : [
+          allowed_urls = try(network.appliance.security_malware.allowed_urls, null) == null ? null : [
             for allowed_url in try(network.appliance.security_malware.allowed_urls, []) : {
               url     = try(allowed_url.url, local.defaults.meraki.domains.organizations.networks.appliance.security_malware.allowed_urls.url, null)
               comment = try(allowed_url.comment, local.defaults.meraki.domains.organizations.networks.appliance.security_malware.allowed_urls.comment, null)
             }
           ]
-          allowed_files = try(length(network.appliance.security_malware.allowed_files) == 0, true) ? null : [
+          allowed_files = try(network.appliance.security_malware.allowed_files, null) == null ? null : [
             for allowed_file in try(network.appliance.security_malware.allowed_files, []) : {
               sha256  = try(allowed_file.sha256, local.defaults.meraki.domains.organizations.networks.appliance.security_malware.allowed_files.sha256, null)
               comment = try(allowed_file.comment, local.defaults.meraki.domains.organizations.networks.appliance.security_malware.allowed_files.comment, null)
@@ -444,7 +444,7 @@ locals {
           subnet       = try(network.appliance.single_lan.subnet, local.defaults.meraki.domains.organizations.networks.appliance.single_lan.subnet, null)
           appliance_ip = try(network.appliance.single_lan.appliance_ip, local.defaults.meraki.domains.organizations.networks.appliance.single_lan.appliance_ip, null)
           # ipv6_enabled = try(network.appliance.single_lan.ipv6.enabled, local.defaults.meraki.domains.organizations.networks.appliance.single_lan.ipv6.enabled, null)
-          # ipv6_prefix_assignments = try(length(network.appliance.single_lan.ipv6.prefix_assignments) == 0, true) ? null : [
+          # ipv6_prefix_assignments = try(network.appliance.single_lan.ipv6.prefix_assignments, null) == null ? null : [
           #   for ipv6_prefix_assignment in try(network.appliance.single_lan.ipv6.prefix_assignments, []) : {
           #     autonomous           = try(ipv6_prefix_assignment.autonomous, local.defaults.meraki.domains.organizations.networks.appliance.single_lan.ipv6.prefix_assignments.autonomous, null)
           #     static_prefix        = try(ipv6_prefix_assignment.static_prefix, local.defaults.meraki.domains.organizations.networks.appliance.single_lan.ipv6.prefix_assignments.static_prefix, null)
@@ -485,7 +485,7 @@ locals {
             appliance_ip    = try(appliance_vlan.appliance_ip, local.defaults.meraki.domains.organizations.networks.appliance.vlans.appliance_ip, null)
             group_policy_id = try(meraki_network_group_policy.networks_group_policies[format("%s/%s/%s/%s", domain.name, organization.name, network.name, appliance_vlan.group_policy_name)].id, null)
             # ipv6_enabled    = try(appliance_vlan.ipv6.enabled, local.defaults.meraki.domains.organizations.networks.appliance.vlans.ipv6.enabled, null)
-            # ipv6_prefix_assignments = try(length(appliance_vlan.ipv6.prefix_assignments) == 0, true) ? null : [
+            # ipv6_prefix_assignments = try(appliance_vlan.ipv6.prefix_assignments, null) == null ? null : [
             #   for ipv6_prefix_assignment in try(appliance_vlan.ipv6.prefix_assignments, []) : {
             #     autonomous           = try(ipv6_prefix_assignment.autonomous, local.defaults.meraki.domains.organizations.networks.appliance.vlans.ipv6.prefix_assignments.autonomous, null)
             #     disabled             = try(ipv6_prefix_assignment.disabled, local.defaults.meraki.domains.organizations.networks.appliance.vlans.ipv6.prefix_assignments.disabled, null)
@@ -502,7 +502,7 @@ locals {
               dhcp_boot_options_enabled = try(appliance_vlan.dhcp_boot_options, local.defaults.meraki.domains.organizations.networks.appliance.vlans.dhcp_boot_options, null)
               dhcp_handling             = try(appliance_vlan.dhcp_handling, local.defaults.meraki.domains.organizations.networks.appliance.vlans.dhcp_handling, null)
               dhcp_lease_time           = try(appliance_vlan.dhcp_lease_time, local.defaults.meraki.domains.organizations.networks.appliance.vlans.dhcp_lease_time, null)
-              dhcp_options = try(length(appliance_vlan.dhcp_options) == 0, true) ? null : [
+              dhcp_options = try(appliance_vlan.dhcp_options, null) == null ? null : [
                 for dhcp_option in try(appliance_vlan.dhcp_options, []) : {
                   code  = try(dhcp_option.code, local.defaults.meraki.domains.organizations.networks.appliance.vlans.dhcp_options.code, null)
                   type  = try(dhcp_option.type, local.defaults.meraki.domains.organizations.networks.appliance.vlans.dhcp_options.type, null)
@@ -511,14 +511,14 @@ locals {
               ]
               dns_nameservers        = try(appliance_vlan.dns_nameservers, local.defaults.meraki.domains.organizations.networks.appliance.vlans.dns_nameservers, null)
               mandatory_dhcp_enabled = try(appliance_vlan.mandatory_dhcp, local.defaults.meraki.domains.organizations.networks.appliance.vlans.mandatory_dhcp, null)
-              reserved_ip_ranges = try(length(appliance_vlan.reserved_ip_ranges) == 0, true) ? null : [
+              reserved_ip_ranges = try(appliance_vlan.reserved_ip_ranges, null) == null ? null : [
                 for reserved_ip_range in try(appliance_vlan.reserved_ip_ranges, []) : {
                   start   = try(reserved_ip_range.start, local.defaults.meraki.domains.organizations.networks.appliance.vlans.reserved_ip_ranges.start, null)
                   end     = try(reserved_ip_range.end, local.defaults.meraki.domains.organizations.networks.appliance.vlans.reserved_ip_ranges.end, null)
                   comment = try(reserved_ip_range.comment, local.defaults.meraki.domains.organizations.networks.appliance.vlans.reserved_ip_ranges.comment, null)
                 }
               ]
-              fixed_ip_assignments = try(length(appliance_vlan.fixed_ip_assignments) == 0, true) ? null : {
+              fixed_ip_assignments = try(appliance_vlan.fixed_ip_assignments, null) == null ? null : {
                 for fixed_ip_assignment in try(appliance_vlan.fixed_ip_assignments, []) :
                 fixed_ip_assignment.mac => {
                   ip   = try(fixed_ip_assignment.ip, local.defaults.meraki.domains.organizations.networks.appliance.vlans.fixed_ip_assignments.ip, null)
@@ -625,7 +625,7 @@ locals {
           enabled         = try(network.appliance.vpn_bgp.enabled, local.defaults.meraki.domains.organizations.networks.appliance.vpn_bgp.enabled, null)
           as_number       = try(network.appliance.vpn_bgp.as_number, local.defaults.meraki.domains.organizations.networks.appliance.vpn_bgp.as_number, null)
           ibgp_hold_timer = try(network.appliance.vpn_bgp.ibgp_hold_timer, local.defaults.meraki.domains.organizations.networks.appliance.vpn_bgp.ibgp_hold_timer, null)
-          neighbors = try(length(network.appliance.vpn_bgp.neighbors) == 0, true) ? null : [
+          neighbors = try(network.appliance.vpn_bgp.neighbors, null) == null ? null : [
             for neighbor in try(network.appliance.vpn_bgp.neighbors, []) : {
               ip                      = try(neighbor.ip, local.defaults.meraki.domains.organizations.networks.appliance.vpn_bgp.neighbors.ip, null)
               ipv6_address            = try(neighbor.ipv6, local.defaults.meraki.domains.organizations.networks.appliance.vpn_bgp.neighbors.ipv6, null)
@@ -666,13 +666,13 @@ locals {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
           mode       = try(network.appliance.vpn_site_to_site_vpn.mode, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.mode, null)
-          hubs = try(length(network.appliance.vpn_site_to_site_vpn.hubs) == 0, true) ? null : [
+          hubs = try(network.appliance.vpn_site_to_site_vpn.hubs, null) == null ? null : [
             for hub in try(network.appliance.vpn_site_to_site_vpn.hubs, []) : {
               hub_id            = local.network_ids[format("%s/%s/%s", domain.name, organization.name, hub.hub_network_name)]
               use_default_route = try(hub.use_default_route, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.hubs.use_default_route, null)
             }
           ]
-          subnets = try(length(network.appliance.vpn_site_to_site_vpn.subnets) == 0, true) ? null : [
+          subnets = try(network.appliance.vpn_site_to_site_vpn.subnets, null) == null ? null : [
             for subnet in try(network.appliance.vpn_site_to_site_vpn.subnets, []) : {
               local_subnet      = try(subnet.local_subnet, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.subnets.local_subnet, null)
               use_vpn           = try(subnet.use_vpn, local.defaults.meraki.domains.organizations.networks.appliance.vpn_site_to_site_vpn.subnets.use_vpn, null)
@@ -788,7 +788,7 @@ locals {
                   source_host      = try(traffic_filter.value.source.host, local.defaults.meraki.domains.organizations.networks.appliance.sdwan_internet_policies.traffic_filters.value.source.host, null)
                   destination_port = try(traffic_filter.value.destination.port, local.defaults.meraki.domains.organizations.networks.appliance.sdwan_internet_policies.traffic_filters.value.destination.port, null)
                   destination_cidr = try(traffic_filter.value.destination.cidr, local.defaults.meraki.domains.organizations.networks.appliance.sdwan_internet_policies.traffic_filters.value.destination.cidr, null)
-                  destination_applications = try(length(traffic_filter.value.destination.applications) == 0, true) ? null : [
+                  destination_applications = try(traffic_filter.value.destination.applications, null) == null ? null : [
                     for value_destination_application in try(traffic_filter.value.destination.applications, []) : {
                       id   = try(value_destination_application.id, local.defaults.meraki.domains.organizations.networks.appliance.sdwan_internet_policies.traffic_filters.value.destination.applications.id, null)
                       name = try(value_destination_application.name, local.defaults.meraki.domains.organizations.networks.appliance.sdwan_internet_policies.traffic_filters.value.destination.applications.name, null)
@@ -881,7 +881,7 @@ locals {
           key                   = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id            = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
           default_rules_enabled = try(network.appliance.traffic_shaping.rules.default_rules, local.defaults.meraki.domains.organizations.networks.appliance.traffic_shaping.rules.default_rules, null)
-          rules = try(length(network.appliance.traffic_shaping.rules.rules) == 0, true) ? null : [
+          rules = try(network.appliance.traffic_shaping.rules.rules, null) == null ? null : [
             for rule in try(network.appliance.traffic_shaping.rules.rules, []) : {
               definitions = [
                 for definition in try(rule.definitions, []) : {
@@ -959,7 +959,7 @@ locals {
           load_balancing_enabled                  = try(network.appliance.traffic_shaping.uplink_selection.load_balancing, local.defaults.meraki.domains.organizations.networks.appliance.traffic_shaping.uplink_selection.load_balancing, null)
           failover_and_failback_immediate_enabled = try(network.appliance.traffic_shaping.uplink_selection.failover_and_failback_immediate, local.defaults.meraki.domains.organizations.networks.appliance.traffic_shaping.uplink_selection.failover_and_failback_immediate, null)
 
-          wan_traffic_uplink_preferences = try(length(network.appliance.traffic_shaping.uplink_selection.wan_traffic_uplink_preferences) == 0, true) ? null : [
+          wan_traffic_uplink_preferences = try(network.appliance.traffic_shaping.uplink_selection.wan_traffic_uplink_preferences, null) == null ? null : [
             for wan_traffic_uplink_preference in try(network.appliance.traffic_shaping.uplink_selection.wan_traffic_uplink_preferences, []) : {
               traffic_filters = [
                 for traffic_filter in try(wan_traffic_uplink_preference.traffic_filters, []) : {
@@ -977,7 +977,7 @@ locals {
             }
           ]
 
-          vpn_traffic_uplink_preferences = try(length(network.appliance.traffic_shaping.uplink_selection.vpn_traffic_uplink_preferences) == 0, true) ? null : [
+          vpn_traffic_uplink_preferences = try(network.appliance.traffic_shaping.uplink_selection.vpn_traffic_uplink_preferences, null) == null ? null : [
             for vpn_traffic_uplink_preference in try(network.appliance.traffic_shaping.uplink_selection.vpn_traffic_uplink_preferences, []) : {
               traffic_filters = [
                 for traffic_filter in try(vpn_traffic_uplink_preference.traffic_filters, []) : {
@@ -1032,14 +1032,14 @@ locals {
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-          custom = try(length(network.appliance.traffic_shaping.vpn_exclusions.custom) == 0, true) ? null : [
+          custom = try(network.appliance.traffic_shaping.vpn_exclusions.custom, null) == null ? null : [
             for custom in try(network.appliance.traffic_shaping.vpn_exclusions.custom, []) : {
               protocol    = try(custom.protocol, local.defaults.meraki.domains.organizations.networks.appliance.traffic_shaping.vpn_exclusions.custom.protocol, null)
               destination = try(custom.destination, local.defaults.meraki.domains.organizations.networks.appliance.traffic_shaping.vpn_exclusions.custom.destination, null)
               port        = try(custom.port, local.defaults.meraki.domains.organizations.networks.appliance.traffic_shaping.vpn_exclusions.custom.port, null)
             }
           ]
-          major_applications = try(length(network.appliance.traffic_shaping.vpn_exclusions.major_applications) == 0, true) ? null : [
+          major_applications = try(network.appliance.traffic_shaping.vpn_exclusions.major_applications, null) == null ? null : [
             for major_application in try(network.appliance.traffic_shaping.vpn_exclusions.major_applications, []) : {
               id = major_application
             }
@@ -1075,7 +1075,7 @@ locals {
             default_vlan_id = try(appliance_ssid.default_vlan_id, local.defaults.meraki.domains.organizations.networks.appliance.ssids.default_vlan_id, null)
             auth_mode       = try(appliance_ssid.auth_mode, local.defaults.meraki.domains.organizations.networks.appliance.ssids.auth_mode, null)
             psk             = try(appliance_ssid.psk, local.defaults.meraki.domains.organizations.networks.appliance.ssids.psk, null)
-            radius_servers = try(length(appliance_ssid.radius_servers) == 0, true) ? null : [
+            radius_servers = try(appliance_ssid.radius_servers, null) == null ? null : [
               for radius_server in try(appliance_ssid.radius_servers, []) : {
                 host   = try(radius_server.host, local.defaults.meraki.domains.organizations.networks.appliance.ssids.radius_servers.host, null)
                 port   = try(radius_server.port, local.defaults.meraki.domains.organizations.networks.appliance.ssids.radius_servers.port, null)

--- a/meraki_devices.tf
+++ b/meraki_devices.tf
@@ -304,21 +304,21 @@ locals {
               boot_options_enabled   = try(switch_routing_interface.dhcp.boot_options, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.boot_options, null)
               boot_next_server       = try(switch_routing_interface.dhcp.boot_next_server, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.boot_next_server, null)
               boot_file_name         = try(switch_routing_interface.dhcp.boot_file_name, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.boot_file_name, null)
-              dhcp_options = try(length(switch_routing_interface.dhcp.dhcp_options) == 0, true) ? null : [
+              dhcp_options = try(switch_routing_interface.dhcp.dhcp_options, null) == null ? null : [
                 for dhcp_option in try(switch_routing_interface.dhcp.dhcp_options, []) : {
                   code  = try(dhcp_option.code, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.dhcp_options.code, null)
                   type  = try(dhcp_option.type, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.dhcp_options.type, null)
                   value = try(dhcp_option.value, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.dhcp_options.value, null)
                 }
               ]
-              reserved_ip_ranges = try(length(switch_routing_interface.dhcp.reserved_ip_ranges) == 0, true) ? null : [
+              reserved_ip_ranges = try(switch_routing_interface.dhcp.reserved_ip_ranges, null) == null ? null : [
                 for reserved_ip_range in try(switch_routing_interface.dhcp.reserved_ip_ranges, []) : {
                   start   = try(reserved_ip_range.start, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.reserved_ip_ranges.start, null)
                   end     = try(reserved_ip_range.end, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.reserved_ip_ranges.end, null)
                   comment = try(reserved_ip_range.comment, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.reserved_ip_ranges.comment, null)
                 }
               ]
-              fixed_ip_assignments = try(length(switch_routing_interface.dhcp.fixed_ip_assignments) == 0, true) ? null : [
+              fixed_ip_assignments = try(switch_routing_interface.dhcp.fixed_ip_assignments, null) == null ? null : [
                 for fixed_ip_assignment in try(switch_routing_interface.dhcp.fixed_ip_assignments, []) : {
                   name = try(fixed_ip_assignment.name, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.fixed_ip_assignments.name, null)
                   mac  = try(fixed_ip_assignment.mac, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.fixed_ip_assignments.mac, null)
@@ -487,11 +487,11 @@ locals {
           for device in try(network.devices, []) : {
             key    = format("%s/%s/%s/%s", domain.name, organization.name, network.name, device.name)
             serial = meraki_device.devices[format("%s/%s/%s/%s", domain.name, organization.name, network.name, device.name)].serial
-            sims = try(length(device.cellular_sims.sims) == 0, true) ? null : [
+            sims = try(device.cellular_sims.sims, null) == null ? null : [
               for sim in try(device.cellular_sims.sims, []) : {
                 slot       = try(sim.slot, local.defaults.meraki.domains.organizations.networks.devices.cellular_sims.sims.slot, null)
                 is_primary = try(sim.is_primary, local.defaults.meraki.domains.organizations.networks.devices.cellular_sims.sims.is_primary, null)
-                apns = try(length(sim.apns) == 0, true) ? null : [
+                apns = try(sim.apns, null) == null ? null : [
                   for apn in try(sim.apns, []) : {
                     name                    = try(apn.name, local.defaults.meraki.domains.organizations.networks.devices.cellular_sims.sims.apns.name, null)
                     allowed_ip_types        = try(apn.allowed_ip_types, local.defaults.meraki.domains.organizations.networks.devices.cellular_sims.sims.apns.allowed_ip_types, null)

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -33,7 +33,7 @@ locals {
             bandwidth_limit_up                    = try(group_policy.bandwidth.bandwidth_limits.limit_up, local.defaults.meraki.domains.organizations.networks.group_policies.bandwidth.bandwidth_limits.limit_up, null)
             bandwidth_limit_down                  = try(group_policy.bandwidth.bandwidth_limits.limit_down, local.defaults.meraki.domains.organizations.networks.group_policies.bandwidth.bandwidth_limits.limit_down, null)
             firewall_and_traffic_shaping_settings = try(group_policy.firewall_and_traffic_shaping.settings, local.defaults.meraki.domains.organizations.networks.group_policies.firewall_and_traffic_shaping.settings, null)
-            traffic_shaping_rules = try(length(group_policy.firewall_and_traffic_shaping.traffic_shaping_rules) == 0, true) ? null : [
+            traffic_shaping_rules = try(group_policy.firewall_and_traffic_shaping.traffic_shaping_rules, null) == null ? null : [
               for firewall_and_traffic_shaping_traffic_shaping_rule in try(group_policy.firewall_and_traffic_shaping.traffic_shaping_rules, []) : {
                 definitions = [
                   for definition in try(firewall_and_traffic_shaping_traffic_shaping_rule.definitions, []) : {
@@ -49,7 +49,7 @@ locals {
                 priority                                                = try(firewall_and_traffic_shaping_traffic_shaping_rule.priority, local.defaults.meraki.domains.organizations.networks.group_policies.firewall_and_traffic_shaping.traffic_shaping_rules.priority, null)
               }
             ]
-            l3_firewall_rules = try(length(group_policy.firewall_and_traffic_shaping.l3_firewall_rules) == 0, true) ? null : [
+            l3_firewall_rules = try(group_policy.firewall_and_traffic_shaping.l3_firewall_rules, null) == null ? null : [
               for firewall_and_traffic_shaping_l3_firewall_rule in try(group_policy.firewall_and_traffic_shaping.l3_firewall_rules, []) : {
                 comment   = try(firewall_and_traffic_shaping_l3_firewall_rule.comment, local.defaults.meraki.domains.organizations.networks.group_policies.firewall_and_traffic_shaping.l3_firewall_rules.comment, null)
                 policy    = try(firewall_and_traffic_shaping_l3_firewall_rule.policy, local.defaults.meraki.domains.organizations.networks.group_policies.firewall_and_traffic_shaping.l3_firewall_rules.policy, null)
@@ -58,7 +58,7 @@ locals {
                 dest_cidr = try(firewall_and_traffic_shaping_l3_firewall_rule.destination_cidr, local.defaults.meraki.domains.organizations.networks.group_policies.firewall_and_traffic_shaping.l3_firewall_rules.destination_cidr, null)
               }
             ]
-            l7_firewall_rules = try(length(group_policy.firewall_and_traffic_shaping.l7_firewall_rules) == 0, true) ? null : [
+            l7_firewall_rules = try(group_policy.firewall_and_traffic_shaping.l7_firewall_rules, null) == null ? null : [
               for firewall_and_traffic_shaping_l7_firewall_rule in try(group_policy.firewall_and_traffic_shaping.l7_firewall_rules, []) : {
                 policy = try(firewall_and_traffic_shaping_l7_firewall_rule.policy, local.defaults.meraki.domains.organizations.networks.group_policies.firewall_and_traffic_shaping.l7_firewall_rules.policy, null)
                 type   = try(firewall_and_traffic_shaping_l7_firewall_rule.type, local.defaults.meraki.domains.organizations.networks.group_policies.firewall_and_traffic_shaping.l7_firewall_rules.type, null)
@@ -75,7 +75,7 @@ locals {
             vlan_tagging_settings                             = try(group_policy.vlan_tagging.settings, local.defaults.meraki.domains.organizations.networks.group_policies.vlan_tagging.settings, null)
             vlan_tagging_vlan_id                              = try(group_policy.vlan_tagging.vlan_id, local.defaults.meraki.domains.organizations.networks.group_policies.vlan_tagging.vlan_id, null)
             bonjour_forwarding_settings                       = try(group_policy.bonjour_forwarding.settings, local.defaults.meraki.domains.organizations.networks.group_policies.bonjour_forwarding.settings, null)
-            bonjour_forwarding_rules = try(length(group_policy.bonjour_forwarding.rules) == 0, true) ? null : [
+            bonjour_forwarding_rules = try(group_policy.bonjour_forwarding.rules, null) == null ? null : [
               for bonjour_forwarding_rule in try(group_policy.bonjour_forwarding.rules, []) : {
                 description = try(bonjour_forwarding_rule.description, local.defaults.meraki.domains.organizations.networks.group_policies.bonjour_forwarding.rules.description, null)
                 vlan_id     = try(bonjour_forwarding_rule.vlan_id, local.defaults.meraki.domains.organizations.networks.group_policies.bonjour_forwarding.rules.vlan_id, null)
@@ -176,7 +176,7 @@ locals {
           network_id       = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
           access           = try(network.snmp.access, local.defaults.meraki.domains.organizations.networks.snmp.access, null)
           community_string = try(network.snmp.community_string, local.defaults.meraki.domains.organizations.networks.snmp.community_string, null)
-          users = try(length(network.snmp.users) == 0, true) ? null : [
+          users = try(network.snmp.users, null) == null ? null : [
             for user in try(network.snmp.users, []) : {
               username   = try(user.username, local.defaults.meraki.domains.organizations.networks.snmp.users.username, null)
               passphrase = try(user.passphrase, local.defaults.meraki.domains.organizations.networks.snmp.users.passphrase, null)

--- a/meraki_organization.tf
+++ b/meraki_organization.tf
@@ -5,7 +5,7 @@ locals {
         key     = format("%s/%s", domain.name, organization.name)
         name    = try(organization.name, local.defaults.meraki.domains.organizations.name, null)
         managed = try(organization.managed, local.defaults.meraki.domains.organizations.managed, true)
-        management_details = try(length(organization.management) == 0, true) ? null : [
+        management_details = try(organization.management, null) == null ? null : [
           for management in try(organization.management, []) : {
             name  = try(management.name, local.defaults.meraki.domains.organizations.management.name, null)
             value = try(management.value, local.defaults.meraki.domains.organizations.management.value, null)
@@ -187,13 +187,13 @@ locals {
           email           = try(admin.email, local.defaults.meraki.domains.organizations.admins.email, null)
           name            = try(admin.name, local.defaults.meraki.domains.organizations.admins.name, null)
           org_access      = try(admin.organization_access, local.defaults.meraki.domains.organizations.admins.organization_access, null)
-          tags = try(length(admin.tags) == 0, true) ? null : [
+          tags = try(admin.tags, null) == null ? null : [
             for tag in try(admin.tags, []) : {
               tag    = tag.tag
               access = try(tag.access, local.defaults.meraki.domains.organizations.admins.tags.access, null)
             }
           ]
-          networks = try(length(admin.networks) == 0, true) ? null : [
+          networks = try(admin.networks, null) == null ? null : [
             for network in try(admin.networks, []) : {
               id     = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
               access = try(network.access, local.defaults.meraki.domains.organizations.admins.networks.access, null)
@@ -223,7 +223,7 @@ locals {
       for organization in try(domain.organizations, []) : {
         key             = format("%s/%s", domain.name, organization.name)
         organization_id = local.organization_ids[format("%s/%s", domain.name, organization.name)]
-        licenses = try(length(organization.inventory.licenses) == 0, true) ? null : [
+        licenses = try(organization.inventory.licenses, null) == null ? null : [
           for license in try(organization.inventory.licenses, []) : {
             key  = license.key
             mode = license.mode
@@ -251,7 +251,7 @@ locals {
       for organization in try(domain.organizations, []) : {
         key             = format("%s/%s", domain.name, organization.name)
         organization_id = local.organization_ids[format("%s/%s", domain.name, organization.name)]
-        enabled_networks = try(length(organization.adaptive_policy.settings_enabled_networks) == 0, true) ? null : [
+        enabled_networks = try(organization.adaptive_policy.settings_enabled_networks, null) == null ? null : [
           for network in try(organization.adaptive_policy.settings_enabled_networks, []) :
           local.network_ids[format("%s/%s/%s", domain.name, organization.name, network)]
         ]
@@ -346,7 +346,7 @@ locals {
           destination_group_sgt  = try(adaptive_policy_policy.destination_group.sgt, local.defaults.meraki.domains.organizations.adaptive_policy.policies.destination_group.sgt, null)
           destination_group_id   = meraki_organization_adaptive_policy_group.organizations_adaptive_policy_groups[format("%s/%s/%s", domain.name, organization.name, adaptive_policy_policy.destination_group.name)].id
           last_entry_rule        = try(adaptive_policy_policy.last_entry_rule, local.defaults.meraki.domains.organizations.adaptive_policy.policies.last_entry_rule, null)
-          acls = try(length(adaptive_policy_policy.acls) == 0, true) ? null : [
+          acls = try(adaptive_policy_policy.acls, null) == null ? null : [
             for acl in try(adaptive_policy_policy.acls, []) : {
               id   = meraki_organization_adaptive_policy_acl.organizations_adaptive_policy_acls[format("%s/%s/%s", domain.name, organization.name, acl)].id
               name = acl
@@ -412,7 +412,7 @@ locals {
           organization_id = local.organization_ids[format("%s/%s", domain.name, organization.name)]
           name            = try(policy_objects_group.name, local.defaults.meraki.domains.organizations.policy_objects_groups.name, null)
           category        = try(policy_objects_group.category, local.defaults.meraki.domains.organizations.policy_objects_groups.category, null)
-          object_ids = try(length(policy_objects_group.object_names) == 0, true) ? null : [
+          object_ids = try(policy_objects_group.object_names, null) == null ? null : [
             for name in try(policy_objects_group.object_names, []) : meraki_organization_policy_object.organizations_policy_objects[format("%s/%s/%s", domain.name, organization.name, name)].id
           ]
         }
@@ -501,7 +501,7 @@ locals {
       for organization in try(domain.organizations, []) : {
         key             = format("%s/%s", domain.name, organization.name)
         organization_id = local.organization_ids[format("%s/%s", domain.name, organization.name)]
-        rules = try(length(organization.appliance.vpn_firewall_rules.rules) == 0, true) ? null : [
+        rules = try(organization.appliance.vpn_firewall_rules.rules, null) == null ? null : [
           for rule in try(organization.appliance.vpn_firewall_rules.rules, []) : {
             comment        = try(rule.comment, local.defaults.meraki.domains.organizations.appliance.vpn_firewall_rules.rules.comment, null)
             policy         = try(rule.policy, local.defaults.meraki.domains.organizations.appliance.vpn_firewall_rules.rules.policy, null)
@@ -537,7 +537,7 @@ locals {
           key             = format("%s/%s/%s", domain.name, organization.name, early_access_features_opt_in.short_name)
           organization_id = local.organization_ids[format("%s/%s", domain.name, organization.name)]
           short_name      = try(early_access_features_opt_in.short_name, local.defaults.meraki.domains.organizations.early_access_features_opt_ins.short_name, null)
-          limit_scope_to_networks = try(length(early_access_features_opt_in.limit_scope_to_networks) == 0, true) ? null : [
+          limit_scope_to_networks = try(early_access_features_opt_in.limit_scope_to_networks, null) == null ? null : [
             for network_name in try(early_access_features_opt_in.limit_scope_to_networks, []) :
             local.network_ids[format("%s/%s/%s", domain.name, organization.name, network_name)]
           ]

--- a/meraki_switches.tf
+++ b/meraki_switches.tf
@@ -59,7 +59,7 @@ locals {
             radius_testing_enabled                   = try(switch_access_policy.radius_testing, local.defaults.meraki.domains.organizations.networks.switch.access_policies.radius_testing, null)
             radius_coa_support_enabled               = try(switch_access_policy.radius_coa_support, local.defaults.meraki.domains.organizations.networks.switch.access_policies.radius_coa_support, null)
             radius_accounting_enabled                = try(switch_access_policy.radius_accounting, local.defaults.meraki.domains.organizations.networks.switch.access_policies.radius_accounting, null)
-            radius_accounting_servers = try(length(switch_access_policy.radius_accounting_servers) == 0, true) ? null : [
+            radius_accounting_servers = try(switch_access_policy.radius_accounting_servers, null) == null ? null : [
               for radius_accounting_server in try(switch_access_policy.radius_accounting_servers, []) : {
                 # TODO Map from organization_radius_server_name.
                 organization_radius_server_id = try(radius_accounting_server.organization_radius_server_id, local.defaults.meraki.domains.organizations.networks.switch.access_policies.radius_accounting_servers.organization_radius_server_id, null)
@@ -122,7 +122,7 @@ locals {
           enabled    = try(network.switch.alternate_management_interface.enabled, local.defaults.meraki.domains.organizations.networks.switch.alternate_management_interface.enabled, null)
           vlan_id    = try(network.switch.alternate_management_interface.vlan_id, local.defaults.meraki.domains.organizations.networks.switch.alternate_management_interface.vlan_id, null)
           protocols  = try(network.switch.alternate_management_interface.protocols, local.defaults.meraki.domains.organizations.networks.switch.alternate_management_interface.protocols, null)
-          switches = try(length(network.switch.alternate_management_interface.switches) == 0, true) ? null : [
+          switches = try(network.switch.alternate_management_interface.switches, null) == null ? null : [
             for switch in try(network.switch.alternate_management_interface.switches, []) : {
               serial                  = meraki_device.devices[format("%s/%s/%s/%s", domain.name, organization.name, network.name, switch.device)].serial
               alternate_management_ip = try(switch.alternate_management_ip, local.defaults.meraki.domains.organizations.networks.switch.alternate_management_interface.switches.alternate_management_ip, null)
@@ -237,13 +237,13 @@ locals {
           for switch_link_aggregation in try(network.switch.link_aggregations, []) : {
             key        = format("%s/%s/%s/%s", domain.name, organization.name, network.name, switch_link_aggregation.link_aggregation_name)
             network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-            switch_ports = try(length(switch_link_aggregation.switch_ports) == 0, true) ? null : [
+            switch_ports = try(switch_link_aggregation.switch_ports, null) == null ? null : [
               for switch_port in try(switch_link_aggregation.switch_ports, []) : {
                 serial  = meraki_device.devices[format("%s/%s/%s/%s", domain.name, organization.name, network.name, switch_port.device)].serial
                 port_id = try(switch_port.port_id, local.defaults.meraki.domains.organizations.networks.switch.link_aggregations.switch_ports.port_id, null)
               }
             ]
-            switch_profile_ports = try(length(switch_link_aggregation.switch_profile_ports) == 0, true) ? null : [
+            switch_profile_ports = try(switch_link_aggregation.switch_profile_ports, null) == null ? null : [
               for switch_profile_port in try(switch_link_aggregation.switch_profile_ports, []) : {
                 profile = try(switch_profile_port.profile, local.defaults.meraki.domains.organizations.networks.switch.link_aggregations.switch_profile_ports.profile, null)
                 port_id = try(switch_profile_port.port_id, local.defaults.meraki.domains.organizations.networks.switch.link_aggregations.switch_profile_ports.port_id, null)
@@ -274,7 +274,7 @@ locals {
           key              = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id       = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
           default_mtu_size = try(network.switch.mtu.default_mtu_size, local.defaults.meraki.domains.organizations.networks.switch.mtu.default_mtu_size, null)
-          overrides = try(length(network.switch.mtu.overrides) == 0, true) ? null : [
+          overrides = try(network.switch.mtu.overrides, null) == null ? null : [
             for override in try(network.switch.mtu.overrides, []) : {
               # TODO Map from device names to serials?
               switches        = try(override.switches, local.defaults.meraki.domains.organizations.networks.switch.mtu.overrides.switches, null)
@@ -432,7 +432,7 @@ locals {
           network_id                                               = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
           default_settings_igmp_snooping_enabled                   = try(network.switch.routing_multicast.default_settings.igmp_snooping, local.defaults.meraki.domains.organizations.networks.switch.routing_multicast.default_settings.igmp_snooping, null)
           default_settings_flood_unknown_multicast_traffic_enabled = try(network.switch.routing_multicast.default_settings.flood_unknown_multicast_traffic, local.defaults.meraki.domains.organizations.networks.switch.routing_multicast.default_settings.flood_unknown_multicast_traffic, null)
-          overrides = try(length(network.switch.routing_multicast.overrides) == 0, true) ? null : [
+          overrides = try(network.switch.routing_multicast.overrides, null) == null ? null : [
             for override in try(network.switch.routing_multicast.overrides, []) : {
               switch_profiles = try(override.switch_profiles, local.defaults.meraki.domains.organizations.networks.switch.routing_multicast.overrides.switch_profiles, null)
               # TODO Map from device names to serials?
@@ -497,7 +497,7 @@ locals {
           enabled                = try(network.switch.routing_ospf.enabled, local.defaults.meraki.domains.organizations.networks.switch.routing_ospf.enabled, null)
           hello_timer_in_seconds = try(network.switch.routing_ospf.hello_timer_in_seconds, local.defaults.meraki.domains.organizations.networks.switch.routing_ospf.hello_timer_in_seconds, null)
           dead_timer_in_seconds  = try(network.switch.routing_ospf.dead_timer_in_seconds, local.defaults.meraki.domains.organizations.networks.switch.routing_ospf.dead_timer_in_seconds, null)
-          areas = try(length(network.switch.routing_ospf.areas) == 0, true) ? null : [
+          areas = try(network.switch.routing_ospf.areas, null) == null ? null : [
             for area in try(network.switch.routing_ospf.areas, []) : {
               area_id   = try(area.area_id, local.defaults.meraki.domains.organizations.networks.switch.routing_ospf.areas.area_id, null)
               area_name = try(area.area_name, local.defaults.meraki.domains.organizations.networks.switch.routing_ospf.areas.area_name, null)
@@ -507,7 +507,7 @@ locals {
           v3_enabled                = try(network.switch.routing_ospf.v3.enabled, local.defaults.meraki.domains.organizations.networks.switch.routing_ospf.v3.enabled, null)
           v3_hello_timer_in_seconds = try(network.switch.routing_ospf.v3.hello_timer_in_seconds, local.defaults.meraki.domains.organizations.networks.switch.routing_ospf.v3.hello_timer_in_seconds, null)
           v3_dead_timer_in_seconds  = try(network.switch.routing_ospf.v3.dead_timer_in_seconds, local.defaults.meraki.domains.organizations.networks.switch.routing_ospf.v3.dead_timer_in_seconds, null)
-          v3_areas = try(length(network.switch.routing_ospf.v3.areas) == 0, true) ? null : [
+          v3_areas = try(network.switch.routing_ospf.v3.areas, null) == null ? null : [
             for v3_area in try(network.switch.routing_ospf.v3.areas, []) : {
               area_id   = try(v3_area.area_id, local.defaults.meraki.domains.organizations.networks.switch.routing_ospf.v3.areas.area_id, null)
               area_name = try(v3_area.area_name, local.defaults.meraki.domains.organizations.networks.switch.routing_ospf.v3.areas.area_name, null)
@@ -551,7 +551,7 @@ locals {
           network_id         = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
           vlan               = try(network.switch.settings.vlan, local.defaults.meraki.domains.organizations.networks.switch.settings.vlan, null)
           use_combined_power = try(network.switch.settings.use_combined_power, local.defaults.meraki.domains.organizations.networks.switch.settings.use_combined_power, null)
-          power_exceptions = try(length(network.switch.settings.power_exceptions) == 0, true) ? null : [
+          power_exceptions = try(network.switch.settings.power_exceptions, null) == null ? null : [
             for power_exception in try(network.switch.settings.power_exceptions, []) : {
               serial     = meraki_device.devices[format("%s/%s/%s/%s", domain.name, organization.name, network.name, power_exception.device)].serial
               power_type = try(power_exception.power_type, local.defaults.meraki.domains.organizations.networks.switch.settings.power_exceptions.power_type, null)
@@ -615,14 +615,14 @@ locals {
           key          = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id   = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
           rstp_enabled = try(network.switch.stp.rstp, local.defaults.meraki.domains.organizations.networks.switch.stp.rstp, null)
-          stp_bridge_priority = try(length(network.switch.stp.stp_bridge_priority) == 0, true) ? null : [
+          stp_bridge_priority = try(network.switch.stp.stp_bridge_priority, null) == null ? null : [
             for stp_bridge_priority in try(network.switch.stp.stp_bridge_priority, []) : {
               switch_profiles = try(stp_bridge_priority.switch_profiles, local.defaults.meraki.domains.organizations.networks.switch.stp.stp_bridge_priority.switch_profiles, null)
-              switches = try(length(stp_bridge_priority.switches) == 0, true) ? null : [
+              switches = try(stp_bridge_priority.switches, null) == null ? null : [
                 for switch in try(stp_bridge_priority.switches, []) :
                 meraki_device.devices[format("%s/%s/%s/%s", domain.name, organization.name, network.name, switch)].serial
               ]
-              stacks = try(length(stp_bridge_priority.stacks) == 0, true) ? null : [
+              stacks = try(stp_bridge_priority.stacks, null) == null ? null : [
                 for stack in try(stp_bridge_priority.stacks, []) :
                 meraki_switch_stack.networks_switch_stacks[format("%s/%s/%s/%s", domain.name, organization.name, network.name, stack)].id
               ]
@@ -785,21 +785,21 @@ locals {
               boot_options_enabled   = try(routing_interface.dhcp.boot_options, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.dhcp.boot_options, null)
               boot_next_server       = try(routing_interface.dhcp.boot_next_server, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.dhcp.boot_next_server, null)
               boot_file_name         = try(routing_interface.dhcp.boot_file_name, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.dhcp.boot_file_name, null)
-              dhcp_options = try(length(routing_interface.dhcp.dhcp_options) == 0, true) ? null : [
+              dhcp_options = try(routing_interface.dhcp.dhcp_options, null) == null ? null : [
                 for dhcp_option in try(routing_interface.dhcp.dhcp_options, []) : {
                   code  = try(dhcp_option.code, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.dhcp.dhcp_options.code, null)
                   type  = try(dhcp_option.type, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.dhcp.dhcp_options.type, null)
                   value = try(dhcp_option.value, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.dhcp.dhcp_options.value, null)
                 }
               ]
-              reserved_ip_ranges = try(length(routing_interface.dhcp.reserved_ip_ranges) == 0, true) ? null : [
+              reserved_ip_ranges = try(routing_interface.dhcp.reserved_ip_ranges, null) == null ? null : [
                 for reserved_ip_range in try(routing_interface.dhcp.reserved_ip_ranges, []) : {
                   start   = try(reserved_ip_range.start, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.dhcp.reserved_ip_ranges.start, null)
                   end     = try(reserved_ip_range.end, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.dhcp.reserved_ip_ranges.end, null)
                   comment = try(reserved_ip_range.comment, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.dhcp.reserved_ip_ranges.comment, null)
                 }
               ]
-              fixed_ip_assignments = try(length(routing_interface.dhcp.fixed_ip_assignments) == 0, true) ? null : [
+              fixed_ip_assignments = try(routing_interface.dhcp.fixed_ip_assignments, null) == null ? null : [
                 for fixed_ip_assignment in try(routing_interface.dhcp.fixed_ip_assignments, []) : {
                   name = try(fixed_ip_assignment.name, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.dhcp.fixed_ip_assignments.name, null)
                   mac  = try(fixed_ip_assignment.mac, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.dhcp.fixed_ip_assignments.mac, null)

--- a/meraki_wireless.tf
+++ b/meraki_wireless.tf
@@ -58,7 +58,7 @@ locals {
             six_ghz_settings_channel_width            = try(wireless_rf_profile.six_ghz_settings.channel_width, local.defaults.meraki.domains.organizations.networks.wireless.rf_profiles.six_ghz_settings.channel_width, null)
             six_ghz_settings_rxsop                    = try(wireless_rf_profile.six_ghz_settings.rxsop, local.defaults.meraki.domains.organizations.networks.wireless.rf_profiles.six_ghz_settings.rxsop, null)
             transmission_enabled                      = try(wireless_rf_profile.transmission, local.defaults.meraki.domains.organizations.networks.wireless.rf_profiles.transmission, null)
-            flex_radios_by_model = try(length(wireless_rf_profile.flex_radios) == 0, true) ? null : [
+            flex_radios_by_model = try(wireless_rf_profile.flex_radios, null) == null ? null : [
               for flex_radio in try(wireless_rf_profile.flex_radios, []) : {
                 model = try(flex_radio.model, local.defaults.meraki.domains.organizations.networks.wireless.rf_profiles.flex_radios.model, null)
                 bands = try(flex_radio.bands, local.defaults.meraki.domains.organizations.networks.wireless.rf_profiles.flex_radios.bands, null)
@@ -225,7 +225,7 @@ locals {
             local_radius_certificate_authentication_use_ocsp                            = try(wireless_ssid.radius.local_radius.certificate_authentication.use_ocsp, local.defaults.meraki.domains.organizations.networks.wireless.ssids.radius.local_radius.certificate_authentication.use_ocsp, null)
             local_radius_certificate_authentication_ocsp_responder_url                  = try(wireless_ssid.radius.local_radius.certificate_authentication.ocsp_responder_url, local.defaults.meraki.domains.organizations.networks.wireless.ssids.radius.local_radius.certificate_authentication.ocsp_responder_url, null)
             local_radius_certificate_authentication_client_root_ca_certificate_contents = try(wireless_ssid.radius.local_radius.certificate_authentication.client_root_ca_certificate, local.defaults.meraki.domains.organizations.networks.wireless.ssids.radius.local_radius.certificate_authentication.client_root_ca_certificate, null)
-            ldap_servers = try(length(wireless_ssid.ldap.servers) == 0, true) ? null : [
+            ldap_servers = try(wireless_ssid.ldap.servers, null) == null ? null : [
               for ldap_server in try(wireless_ssid.ldap.servers, []) : {
                 host = try(ldap_server.host, local.defaults.meraki.domains.organizations.networks.wireless.ssids.ldap.servers.host, null)
                 port = try(ldap_server.port, local.defaults.meraki.domains.organizations.networks.wireless.ssids.ldap.servers.port, null)
@@ -235,7 +235,7 @@ locals {
             ldap_credentials_password           = try(wireless_ssid.ldap.credentials.password, local.defaults.meraki.domains.organizations.networks.wireless.ssids.ldap.credentials.password, null)
             ldap_base_distinguished_name        = try(wireless_ssid.ldap.base_distinguished_name, local.defaults.meraki.domains.organizations.networks.wireless.ssids.ldap.base_distinguished_name, null)
             ldap_server_ca_certificate_contents = try(wireless_ssid.ldap.server_ca_certificate, local.defaults.meraki.domains.organizations.networks.wireless.ssids.ldap.server_ca_certificate, null)
-            active_directory_servers = try(length(wireless_ssid.active_directory.servers) == 0, true) ? null : [
+            active_directory_servers = try(wireless_ssid.active_directory.servers, null) == null ? null : [
               for active_directory_server in try(wireless_ssid.active_directory.servers, []) : {
                 host = try(active_directory_server.host, local.defaults.meraki.domains.organizations.networks.wireless.ssids.active_directory.servers.host, null)
                 port = try(active_directory_server.port, local.defaults.meraki.domains.organizations.networks.wireless.ssids.active_directory.servers.port, null)
@@ -243,7 +243,7 @@ locals {
             ]
             active_directory_credentials_logon_name = try(wireless_ssid.active_directory.credentials.logon_name, local.defaults.meraki.domains.organizations.networks.wireless.ssids.active_directory.credentials.logon_name, null)
             active_directory_credentials_password   = try(wireless_ssid.active_directory.credentials.password, local.defaults.meraki.domains.organizations.networks.wireless.ssids.active_directory.credentials.password, null)
-            radius_servers = try(length(wireless_ssid.radius.servers) == 0, true) ? null : [
+            radius_servers = try(wireless_ssid.radius.servers, null) == null ? null : [
               for radius_server in try(wireless_ssid.radius.servers, []) : {
                 host                        = try(radius_server.host, local.defaults.meraki.domains.organizations.networks.wireless.ssids.radius.servers.host, null)
                 port                        = try(radius_server.port, local.defaults.meraki.domains.organizations.networks.wireless.ssids.radius.servers.port, null)
@@ -265,7 +265,7 @@ locals {
             radius_failover_policy           = try(wireless_ssid.radius.failover_policy, local.defaults.meraki.domains.organizations.networks.wireless.ssids.radius.failover_policy, null)
             radius_load_balancing_policy     = try(wireless_ssid.radius.load_balancing_policy, local.defaults.meraki.domains.organizations.networks.wireless.ssids.radius.load_balancing_policy, null)
             radius_accounting_enabled        = try(wireless_ssid.radius.accounting, local.defaults.meraki.domains.organizations.networks.wireless.ssids.radius.accounting, null)
-            radius_accounting_servers = try(length(wireless_ssid.radius.accounting_servers) == 0, true) ? null : [
+            radius_accounting_servers = try(wireless_ssid.radius.accounting_servers, null) == null ? null : [
               for radius_accounting_server in try(wireless_ssid.radius.accounting_servers, []) : {
                 host           = try(radius_accounting_server.host, local.defaults.meraki.domains.organizations.networks.wireless.ssids.radius.accounting_servers.host, null)
                 port           = try(radius_accounting_server.port, local.defaults.meraki.domains.organizations.networks.wireless.ssids.radius.accounting_servers.port, null)
@@ -285,7 +285,7 @@ locals {
             disassociate_clients_on_vpn_failover = try(wireless_ssid.disassociate_clients_on_vpn_failover, local.defaults.meraki.domains.organizations.networks.wireless.ssids.disassociate_clients_on_vpn_failover, null)
             vlan_id                              = try(wireless_ssid.vlan_id, local.defaults.meraki.domains.organizations.networks.wireless.ssids.vlan_id, null)
             default_vlan_id                      = try(wireless_ssid.default_vlan_id, local.defaults.meraki.domains.organizations.networks.wireless.ssids.default_vlan_id, null)
-            ap_tags_and_vlan_ids = try(length(wireless_ssid.ap_tags_and_vlan_ids) == 0, true) ? null : [
+            ap_tags_and_vlan_ids = try(wireless_ssid.ap_tags_and_vlan_ids, null) == null ? null : [
               for ap_tags_and_vlan_id in try(wireless_ssid.ap_tags_and_vlan_ids, []) : {
                 tags    = try(ap_tags_and_vlan_id.tags, local.defaults.meraki.domains.organizations.networks.wireless.ssids.ap_tags_and_vlan_ids.tags, null)
                 vlan_id = try(ap_tags_and_vlan_id.vlan_id, local.defaults.meraki.domains.organizations.networks.wireless.ssids.ap_tags_and_vlan_ids.vlan_id, null)
@@ -315,7 +315,7 @@ locals {
             speed_burst_enabled                   = try(wireless_ssid.speed_burst, local.defaults.meraki.domains.organizations.networks.wireless.ssids.speed_burst, null)
             named_vlans_tagging_enabled           = try(wireless_ssid.named_vlans.tagging.enabled, local.defaults.meraki.domains.organizations.networks.wireless.ssids.named_vlans.tagging.enabled, null)
             named_vlans_tagging_default_vlan_name = try(wireless_ssid.named_vlans.tagging.default_vlan_name, local.defaults.meraki.domains.organizations.networks.wireless.ssids.named_vlans.tagging.default_vlan_name, null)
-            named_vlans_tagging_by_ap_tags = try(length(wireless_ssid.named_vlans.tagging.by_ap_tags) == 0, true) ? null : [
+            named_vlans_tagging_by_ap_tags = try(wireless_ssid.named_vlans.tagging.by_ap_tags, null) == null ? null : [
               for named_vlans_tagging_by_ap_tag in try(wireless_ssid.named_vlans.tagging.by_ap_tags, []) : {
                 tags      = try(named_vlans_tagging_by_ap_tag.tags, local.defaults.meraki.domains.organizations.networks.wireless.ssids.named_vlans.tagging.by_ap_tags.tags, null)
                 vlan_name = try(named_vlans_tagging_by_ap_tag.vlan_name, local.defaults.meraki.domains.organizations.networks.wireless.ssids.named_vlans.tagging.by_ap_tags.vlan_name, null)
@@ -460,7 +460,7 @@ locals {
             network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
             number     = meraki_wireless_ssid.networks_wireless_ssids[format("%s/%s/%s/%s", domain.name, organization.name, network.name, wireless_ssid.name)].number
             enabled    = try(wireless_ssid.device_type_group_policies.enabled, local.defaults.meraki.domains.organizations.networks.wireless.ssids.device_type_group_policies.enabled, null)
-            device_type_policies = try(length(wireless_ssid.device_type_group_policies.device_type_policies) == 0, true) ? null : [
+            device_type_policies = try(wireless_ssid.device_type_group_policies.device_type_policies, null) == null ? null : [
               for device_type_policy in try(wireless_ssid.device_type_group_policies.device_type_policies, []) : {
                 device_type     = try(device_type_policy.device_type, local.defaults.meraki.domains.organizations.networks.wireless.ssids.device_type_group_policies.device_type_policies.device_type, null)
                 device_policy   = try(device_type_policy.device_policy, local.defaults.meraki.domains.organizations.networks.wireless.ssids.device_type_group_policies.device_type_policies.device_policy, null)
@@ -491,7 +491,7 @@ locals {
             key        = format("%s/%s/%s/%s", domain.name, organization.name, network.name, wireless_ssid.name)
             network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
             number     = meraki_wireless_ssid.networks_wireless_ssids[format("%s/%s/%s/%s", domain.name, organization.name, network.name, wireless_ssid.name)].number
-            rules = try(length(wireless_ssid.firewall_l3_firewall_rules.rules) == 0, true) ? null : [
+            rules = try(wireless_ssid.firewall_l3_firewall_rules.rules, null) == null ? null : [
               for rule in try(wireless_ssid.firewall_l3_firewall_rules.rules, []) : {
                 comment    = try(rule.comment, local.defaults.meraki.domains.organizations.networks.wireless.ssids.firewall_l3_firewall_rules.rules.comment, null)
                 policy     = try(rule.policy, local.defaults.meraki.domains.organizations.networks.wireless.ssids.firewall_l3_firewall_rules.rules.policy, null)
@@ -534,17 +534,17 @@ locals {
             network_access_type = try(wireless_ssid.hotspot20.network_access_type, local.defaults.meraki.domains.organizations.networks.wireless.ssids.hotspot20.network_access_type, null)
             domains             = try(wireless_ssid.hotspot20.domains, local.defaults.meraki.domains.organizations.networks.wireless.ssids.hotspot20.domains, null)
             roam_consort_ois    = try(wireless_ssid.hotspot20.roam_consort_ois, local.defaults.meraki.domains.organizations.networks.wireless.ssids.hotspot20.roam_consort_ois, null)
-            mcc_mncs = try(length(wireless_ssid.hotspot20.mcc_mncs) == 0, true) ? null : [
+            mcc_mncs = try(wireless_ssid.hotspot20.mcc_mncs, null) == null ? null : [
               for mcc_mnc in try(wireless_ssid.hotspot20.mcc_mncs, []) : {
                 mcc = try(mcc_mnc.mcc, local.defaults.meraki.domains.organizations.networks.wireless.ssids.hotspot20.mcc_mncs.mcc, null)
                 mnc = try(mcc_mnc.mnc, local.defaults.meraki.domains.organizations.networks.wireless.ssids.hotspot20.mcc_mncs.mnc, null)
               }
             ]
-            nai_realms = try(length(wireless_ssid.hotspot20.nai_realms) == 0, true) ? null : [
+            nai_realms = try(wireless_ssid.hotspot20.nai_realms, null) == null ? null : [
               for nai_realm in try(wireless_ssid.hotspot20.nai_realms, []) : {
                 format = try(nai_realm.format, local.defaults.meraki.domains.organizations.networks.wireless.ssids.hotspot20.nai_realms.format, null)
                 realm  = try(nai_realm.realm, local.defaults.meraki.domains.organizations.networks.wireless.ssids.hotspot20.nai_realms.realm, null)
-                methods = try(length(nai_realm.methods) == 0, true) ? null : [
+                methods = try(nai_realm.methods, null) == null ? null : [
                   for method in try(nai_realm.methods, []) : {
                     id                                                   = try(method.id, local.defaults.meraki.domains.organizations.networks.wireless.ssids.hotspot20.nai_realms.methods.id, null)
                     authentication_types_non_eap_inner_authentication    = try(method.authentication_types.non_eap_inner_authentication, local.defaults.meraki.domains.organizations.networks.wireless.ssids.hotspot20.nai_realms.methods.authentication_types.non_eap_inner_authentication, null)
@@ -619,7 +619,7 @@ locals {
             network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
             number     = meraki_wireless_ssid.networks_wireless_ssids[format("%s/%s/%s/%s", domain.name, organization.name, network.name, wireless_ssid.name)].number
             enabled    = try(wireless_ssid.unavailability_schedules.enabled, local.defaults.meraki.domains.organizations.networks.wireless.ssids.unavailability_schedules.enabled, null)
-            ranges = try(length(wireless_ssid.unavailability_schedules.ranges) == 0, true) ? null : [
+            ranges = try(wireless_ssid.unavailability_schedules.ranges, null) == null ? null : [
               for range in try(wireless_ssid.unavailability_schedules.ranges, []) : {
                 start_day  = try(range.start_day, local.defaults.meraki.domains.organizations.networks.wireless.ssids.unavailability_schedules.ranges.start_day, null)
                 start_time = try(range.start_time, local.defaults.meraki.domains.organizations.networks.wireless.ssids.unavailability_schedules.ranges.start_time, null)
@@ -627,7 +627,7 @@ locals {
                 end_time   = try(range.end_time, local.defaults.meraki.domains.organizations.networks.wireless.ssids.unavailability_schedules.ranges.end_time, null)
               }
             ]
-            ranges_in_seconds = try(length(wireless_ssid.unavailability_schedules.ranges_in_seconds) == 0, true) ? null : [
+            ranges_in_seconds = try(wireless_ssid.unavailability_schedules.ranges_in_seconds, null) == null ? null : [
               for ranges_in_second in try(wireless_ssid.unavailability_schedules.ranges_in_seconds, []) : {
                 start = try(ranges_in_second.start, local.defaults.meraki.domains.organizations.networks.wireless.ssids.unavailability_schedules.ranges_in_seconds.start, null)
                 end   = try(ranges_in_second.end, local.defaults.meraki.domains.organizations.networks.wireless.ssids.unavailability_schedules.ranges_in_seconds.end, null)
@@ -750,7 +750,7 @@ locals {
             number                  = meraki_wireless_ssid.networks_wireless_ssids[format("%s/%s/%s/%s", domain.name, organization.name, network.name, wireless_ssid.name)].number
             traffic_shaping_enabled = try(wireless_ssid.traffic_shaping_rules.traffic_shaping, local.defaults.meraki.domains.organizations.networks.wireless.ssids.traffic_shaping_rules.traffic_shaping, null)
             default_rules_enabled   = try(wireless_ssid.traffic_shaping_rules.default_rules, local.defaults.meraki.domains.organizations.networks.wireless.ssids.traffic_shaping_rules.default_rules, null)
-            rules = try(length(wireless_ssid.traffic_shaping_rules.rules) == 0, true) ? null : [
+            rules = try(wireless_ssid.traffic_shaping_rules.rules, null) == null ? null : [
               for rule in try(wireless_ssid.traffic_shaping_rules.rules, []) : {
                 definitions = [
                   for definition in try(rule.definitions, []) : {
@@ -792,7 +792,7 @@ locals {
             network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
             number     = meraki_wireless_ssid.networks_wireless_ssids[format("%s/%s/%s/%s", domain.name, organization.name, network.name, wireless_ssid.name)].number
             enabled    = try(wireless_ssid.bonjour_forwarding.enabled, local.defaults.meraki.domains.organizations.networks.wireless.ssids.bonjour_forwarding.enabled, null)
-            rules = try(length(wireless_ssid.bonjour_forwarding.rules) == 0, true) ? null : [
+            rules = try(wireless_ssid.bonjour_forwarding.rules, null) == null ? null : [
               for rule in try(wireless_ssid.bonjour_forwarding.rules, []) : {
                 description = try(rule.description, local.defaults.meraki.domains.organizations.networks.wireless.ssids.bonjour_forwarding.rules.description, null)
                 vlan_id     = try(rule.vlan_id, local.defaults.meraki.domains.organizations.networks.wireless.ssids.bonjour_forwarding.rules.vlan_id, null)
@@ -826,7 +826,7 @@ locals {
           enabled    = try(network.wireless.alternate_management_interface.enabled, local.defaults.meraki.domains.organizations.networks.wireless.alternate_management_interface.enabled, null)
           vlan_id    = try(network.wireless.alternate_management_interface.vlan_id, local.defaults.meraki.domains.organizations.networks.wireless.alternate_management_interface.vlan_id, null)
           protocols  = try(network.wireless.alternate_management_interface.protocols, local.defaults.meraki.domains.organizations.networks.wireless.alternate_management_interface.protocols, null)
-          access_points = try(length(network.wireless.alternate_management_interface.access_points) == 0, true) ? null : [
+          access_points = try(network.wireless.alternate_management_interface.access_points, null) == null ? null : [
             for access_point in try(network.wireless.alternate_management_interface.access_points, []) : {
               serial                  = meraki_device.devices[format("%s/%s/%s/%s", domain.name, organization.name, network.name, access_point.device)].serial
               alternate_management_ip = try(access_point.alternate_management_ip, local.defaults.meraki.domains.organizations.networks.wireless.alternate_management_interface.access_points.alternate_management_ip, null)
@@ -896,7 +896,7 @@ locals {
             key        = format("%s/%s/%s/%s", domain.name, organization.name, network.name, wireless_ssid.name)
             network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
             number     = meraki_wireless_ssid.networks_wireless_ssids[format("%s/%s/%s/%s", domain.name, organization.name, network.name, wireless_ssid.name)].number
-            rules = try(length(wireless_ssid.firewall_l7_firewall_rules) == 0, true) ? null : [
+            rules = try(wireless_ssid.firewall_l7_firewall_rules, null) == null ? null : [
               for firewall_l7_firewall_rule in try(wireless_ssid.firewall_l7_firewall_rules, []) : {
                 policy = try(firewall_l7_firewall_rule.policy, local.defaults.meraki.domains.organizations.networks.wireless.ssids.firewall_l7_firewall_rules.policy, null)
                 type   = try(firewall_l7_firewall_rule.type, local.defaults.meraki.domains.organizations.networks.wireless.ssids.firewall_l7_firewall_rules.type, null)


### PR DESCRIPTION
Instead of converting them to `null`.
This allows the user to clear a list,
which would otherwise keep its old value configured
due to the provider not sending fields with `null` values
in the API request.

Lists of scalars (e.g. strings) already allow that.

Tested for:
- `network.appliance.firewall.inbound_firewall_rules.rules`;
- `network.appliance.firewall.l7_firewall_rules`;
- `network.appliance.firewall.one_to_many_nat_rules`;
- `appliance_firewall_one_to_many_nat_rule.port_rules` (the API requires the list to be non-empty);
- `network.appliance.firewall.one_to_one_nat_rules`;
- `appliance_firewall_one_to_one_nat_rule.allowed_inbound`;
- `network.appliance.firewall.port_forwarding_rules`;
- `network.appliance.security_malware.allowed_urls`;
- `network.appliance.security_malware.allowed_files`;
- `network.appliance.single_lan.ipv6.prefix_assignments` (the API ignores the change and keeps one prefix assignment; the provider does not notice this).

Depends on https://github.com/CiscoDevNet/terraform-provider-meraki/pull/133