### PR TITLE
versions: Update CiscoDevNet/meraki to 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module "meraki" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_meraki"></a> [meraki](#requirement\_meraki) | >= 1.5.0 |
+| <a name="requirement_meraki"></a> [meraki](#requirement\_meraki) | >= 1.8.0 |
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     meraki = {
       source  = "CiscoDevNet/meraki"
-      version = ">= 1.5.0"
+      version = ">= 1.8.0"
     }
   }
 }


### PR DESCRIPTION
For https://github.com/netascode/terraform-meraki-nac-meraki/pull/115 and https://github.com/netascode/terraform-meraki-nac-meraki/pull/116.