### PR TITLE
Revert: is_indoor_default and is_outdoor_default

### DIFF
--- a/meraki_wireless.tf
+++ b/meraki_wireless.tf
@@ -64,19 +64,6 @@ locals {
                 bands = try(flex_radio.bands, local.defaults.meraki.domains.organizations.networks.wireless.rf_profiles.flex_radios.bands, null)
               }
             ]
-            # TODO "terraform destroy" fails if one of is_{in,out}door_default is true.
-            # Changing the value to false beforehand as a workaround is not possible either
-            # (the API ignores the change).
-            # The only workaround is to set a different profile as the default.
-            # To delete just the RF profile,
-            # it should be enough to set "is_indoor_default: true"
-            # in a different profile in the data model.
-            # For "terraform destroy" to succeed,
-            # manually setting one of the built-in profiles ("Basic Indoor Profile", "Basic Outdoor Profile")
-            # in the Dashboard UI is the only way (since those profiles only exist outside of the data model).
-            # https://github.com/CiscoDevNet/terraform-provider-meraki/issues/136
-            # is_indoor_default  = try(wireless_rf_profile.is_indoor_default, local.defaults.meraki.domains.organizations.networks.wireless.rf_profiles.is_indoor_default, null)
-            # is_outdoor_default = try(wireless_rf_profile.is_outdoor_default, local.defaults.meraki.domains.organizations.networks.wireless.rf_profiles.is_outdoor_default, null)
           }
         ]
       ]
@@ -174,19 +161,6 @@ resource "meraki_wireless_rf_profile" "networks_wireless_rf_profiles" {
   per_ssid_settings_14_bands_enabled         = try(each.value.per_ssid_settings[14].bands, null)
   per_ssid_settings_14_band_steering_enabled = try(each.value.per_ssid_settings[14].band_steering_enabled, null)
   flex_radios_by_model                       = each.value.flex_radios_by_model
-  # TODO "terraform destroy" fails if one of is_{in,out}door_default is true.
-  # Changing the value to false beforehand as a workaround is not possible either
-  # (the API ignores the change).
-  # The only workaround is to set a different profile as the default.
-  # To delete just the RF profile,
-  # it should be enough to set "is_indoor_default: true"
-  # in a different profile in the data model.
-  # For "terraform destroy" to succeed,
-  # manually setting one of the built-in profiles ("Basic Indoor Profile", "Basic Outdoor Profile")
-  # in the Dashboard UI is the only way (since those profiles only exist outside of the data model).
-  # https://github.com/CiscoDevNet/terraform-provider-meraki/issues/136
-  # is_indoor_default                          = each.value.is_indoor_default
-  # is_outdoor_default                         = each.value.is_outdoor_default
 }
 
 locals {


### PR DESCRIPTION
Upon further testing of this feature enhancement. We discovered that upon destroy of these objects the API is unable to set to false, unless another profile is set to true. There isnt a simple way to handle this in the provider or the module (https://github.com/CiscoDevNet/terraform-provider-meraki/issues/136).

Reverting this feature until we have a valid solution so that it can be planned and discussed further.

The current valid work around is to assign APs their RF profile, via AP assignment. This is common practice in deployments.

