### PR TITLE
enable IPV6 back on `meraki_appliance_single_lan` and `meraki_appliance_vlan`

### DIFF
--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -482,6 +482,7 @@ locals {
           ipv6_prefix_assignments = try(network.appliance.single_lan.ipv6.prefix_assignments, null) == null ? null : [
             for ipv6_prefix_assignment in try(network.appliance.single_lan.ipv6.prefix_assignments, []) : {
               autonomous           = try(ipv6_prefix_assignment.autonomous, local.defaults.meraki.domains.organizations.networks.appliance.single_lan.ipv6.prefix_assignments.autonomous, null)
+              disabled             = try(ipv6_prefix_assignment.disabled, local.defaults.meraki.domains.organizations.networks.appliance.single_lan.ipv6.prefix_assignments.disabled, null)
               static_prefix        = try(ipv6_prefix_assignment.static_prefix, local.defaults.meraki.domains.organizations.networks.appliance.single_lan.ipv6.prefix_assignments.static_prefix, null)
               static_appliance_ip6 = try(ipv6_prefix_assignment.static_appliance_ip6, local.defaults.meraki.domains.organizations.networks.appliance.single_lan.ipv6.prefix_assignments.static_appliance_ip6, null)
               origin_type          = try(ipv6_prefix_assignment.origin.type, local.defaults.meraki.domains.organizations.networks.appliance.single_lan.ipv6.prefix_assignments.origin.type, null)


### PR DESCRIPTION

- Enable `ipv6_enabled` and `ipv6_prefix_assignments` for `meraki_appliance_single_lan` and `meraki_appliance_vlan` (https://github.com/netascode/terraform-meraki-nac-meraki/pull/139) 
  - Open Caveat: Cannot enable IPV6 while using DHCP Server for IPV4 in the same VLAN. This is a Meraki limitation and will be resolved in a future release. For now, users must choose between enabling IPV6 or using DHCP Server for IPV4 in the same VLAN.
  
- [meraki_appliance: networks_appliance_single_lan: add disabled field](https://github.com/netascode/terraform-meraki-nac-meraki/pull/139/changes/085b2cc632a88fa6918ac4f60aedc9cf9dc59458)
This is required by the API and the provider