### PR TITLE
Fix network_ids reference after concurrent merge

### DIFF
--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -1281,7 +1281,7 @@ locals {
       for organization in try(domain.organizations, []) : [
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
-          network_id = local.network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
+          network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
           rules = [
             for appliance_firewall_inbound_cellular_firewall_rule in try(network.appliance.firewall.inbound_cellular_firewall_rules, []) : {
               comment        = try(appliance_firewall_inbound_cellular_firewall_rule.comment, local.defaults.meraki.domains.organizations.networks.appliance.firewall.inbound_cellular_firewall_rules.comment, null)


### PR DESCRIPTION
These PRs were merged concurrently:
- https://github.com/netascode/terraform-meraki-nac-meraki/pull/145 (3 days earlier);
- https://github.com/netascode/terraform-meraki-nac-meraki/pull/144

The former added a new resource which used `network_ids[]` and the latter renamed all usages of `network_ids`, but was not rebased after the former was merged
and was not updated to also rename the newly-added usage.