### PR TITLE
ci: add merge queue support to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Tests
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Adds `merge_group` trigger to the test workflow so it runs when PRs enter the GitHub merge queue
- This ensures every PR is tested against the **latest `main`** right before merging, preventing broken combinations from landing (e.g., two PRs that pass independently but break when combined)

## Required repo settings
To complete the setup, enable in **Settings → Branches → Branch protection rules** for `main`:
1. **Require merge queue** — forces PRs through the queue instead of direct merge
2. **Add "Tests" as a required status check** — so the queue knows which workflow must pass

## How it works
1. Contributor clicks "Merge when ready" on a PR
2. GitHub creates a temporary merge group (PR merged on top of current `main`)
3. The `merge_group` event fires → this workflow runs against that merged state
4. If tests pass → PR is merged; if they fail → PR is ejected from the queue
5. If `main` moves while a PR is queued → GitHub retests against the new `main`

## Test plan
- [ ] Verify workflow syntax is valid (CI will run on this PR itself)
- [ ] After merging, enable merge queue in repo branch protection settings
- [ ] Test by opening two conflicting PRs and merging them through the queue
Fixes #147 