### PR TITLE
fix: Use correct SSID numbering 1-4 for appliance RF profile per_ssid_settings

### DIFF
--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -1183,7 +1183,7 @@ locals {
           for appliance_rf_profile in try(network.appliance.rf_profiles, []) : {
             key                               = format("%s/%s/%s/%s", domain.name, organization.name, network.name, appliance_rf_profile.name)
             network_id                        = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-            per_ssid_settings                 = [for i in range(4) : try(local.networks_appliance_rf_profiles_per_ssid_settings[format("%s/%s/%s/%s/%s", domain.name, organization.name, network.name, appliance_rf_profile.name, i)], null)]
+            per_ssid_settings                 = [for i in range(1, 5) : try(local.networks_appliance_rf_profiles_per_ssid_settings[format("%s/%s/%s/%s/%s", domain.name, organization.name, network.name, appliance_rf_profile.name, i)], null)]
             name                              = try(appliance_rf_profile.name, local.defaults.meraki.domains.organizations.networks.appliance.rf_profiles.name, null)
             two_four_ghz_settings_min_bitrate = try(appliance_rf_profile.two_four_ghz_settings.min_bitrate, local.defaults.meraki.domains.organizations.networks.appliance.rf_profiles.two_four_ghz_settings.min_bitrate, null)
             two_four_ghz_settings_ax_enabled  = try(appliance_rf_profile.two_four_ghz_settings.ax, local.defaults.meraki.domains.organizations.networks.appliance.rf_profiles.two_four_ghz_settings.ax, null)


### PR DESCRIPTION
## Summary

- Fix appliance RF profile `per_ssid_settings` lookup to use SSID numbers 1-4 instead of 0-3
- Meraki appliance SSIDs are numbered 1-4 in the API (`perSsidSettings.1` through `perSsidSettings.4`), but `range(4)` was producing `[0, 1, 2, 3]` for the lookup keys
- Change `range(4)` to `range(1, 5)` to align with the actual SSID numbers

## Detail

The per_ssid_settings mapping works in two steps:

1. **Build lookup map** — iterates `per_ssid_settings` from YAML, resolves each `ssid_name` to its `.number` via the `meraki_appliance_ssid` resource, and stores the result keyed by `domain/org/network/profile/number`
2. **Build array** — uses `range()` to look up entries by SSID number, then assigns array index `[0]` → `per_ssid_settings_1_*`, `[1]` → `per_ssid_settings_2_*`, etc.

Step 1 correctly stores keys with SSID numbers 1-4 (from the YAML), but step 2 was looking up numbers 0-3 — per-SSID settings were mismatched or missing depending on the SSID.

## Test plan

- [x] `terraform plan` with appliance RF profiles that include `per_ssid_settings` entries
- [x] Verify per_ssid_settings are correctly applied to SSIDs 1-4