### PR TITLE
add support for network module based port_id to meraki_switch_ports

### DIFF
--- a/meraki_devices.tf
+++ b/meraki_devices.tf
@@ -179,7 +179,10 @@ locals {
             ports = [
               for switch_port in try(device.switch.ports, []) : {
                 port_ids = flatten([for port_id_range in switch_port.port_id_ranges : [
-                  for port_id in range(port_id_range.from, port_id_range.to + 1) : port_id
+                  for port_id in range(port_id_range.from, port_id_range.to + 1) :
+                  try(port_id_range.slot, null) != null && try(port_id_range.module, null) != null
+                  ? format("%s_%s_%s", port_id_range.slot, port_id_range.module, port_id)
+                  : port_id
                 ]])
                 data                     = switch_port
                 access_policy_number     = try(meraki_switch_access_policy.networks_switch_access_policies[format("%s/%s/%s/%s", domain.name, organization.name, network.name, switch_port.access_policy_name)].id, null)


### PR DESCRIPTION
add support for network module based port_id to **resource "meraki_switch_ports" "devices_switch_ports"**

new accepted formats

```
- port_id_ranges:
  - slot: 1
	module: C3850-NM-8-10G
	from: 1
	to: 2
  - slot: 1
	module: C3850-NM-8-10G
	from: 5
	to: 6