### PR TITLE
Add changelog for 0.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 
+## 0.7.1
+
+Bug Fixes:
+
+- Fix `templatefile` paths to resolve relative to root module via `path.root` (https://github.com/netascode/terraform-meraki-nac-meraki/pull/148)
+
+New Features:
+
+- Add support for module-based `port_id` format (`slot_module_port`) for modular switch ports (https://github.com/netascode/terraform-meraki-nac-meraki/pull/151)
+- Add `slot` and `module` attributes to `port_id_ranges` in schema for modular switch expansion ports
+- Add mutually inclusive validation rule for `slot` and `module` attributes
+- Add robot test support for module-based port ID resolution
+
+Enhancements:
+
+- Comprehensive defaults updates — add API-validated default values for wireless settings, SSIDs, appliance settings, switch settings, network settings, SNMP, cellular gateway, and organization login security
+- Add `merge_group` trigger to CI test workflow (https://github.com/netascode/terraform-meraki-nac-meraki/pull/148)
+
 ## 0.7.0
 
 New Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,13 @@
 
 ## 0.7.1
 
-Bug Fixes:
-
-- Fix `templatefile` paths to resolve relative to root module via `path.root` (https://github.com/netascode/terraform-meraki-nac-meraki/pull/148)
-
 New Features:
 
 - Add support for module-based `port_id` format (`slot_module_port`) for modular switch ports (https://github.com/netascode/terraform-meraki-nac-meraki/pull/151)
-- Add `slot` and `module` attributes to `port_id_ranges` in schema for modular switch expansion ports
-- Add mutually inclusive validation rule for `slot` and `module` attributes
-- Add robot test support for module-based port ID resolution
 
 Enhancements:
 
 - Comprehensive defaults updates — add API-validated default values for wireless settings, SSIDs, appliance settings, switch settings, network settings, SNMP, cellular gateway, and organization login security
-- Add `merge_group` trigger to CI test workflow (https://github.com/netascode/terraform-meraki-nac-meraki/pull/148)
 
 ## 0.7.0
 


### PR DESCRIPTION
## Summary

- Add CHANGELOG.md entry for the 0.7.1 release covering changes since v0.7.0
- Bug fix: `templatefile` paths resolved relative to root module via `path.root`
- New feature: module-based `port_id` format (`slot_module_port`) for modular switch expansion ports
- New feature: `slot` and `module` schema attributes with mutually inclusive validation
- Enhancements: comprehensive API-validated defaults updates, CI workflow improvements

## Test plan

- [ ] Verify changelog formatting renders correctly on GitHub
- [ ] Verify PR links in changelog are valid