### PR TITLE
fix: add missing depends_on for meraki_appliance_traffic_shaping_vpn_exclusions

### DIFF
--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -1179,6 +1179,8 @@ resource "meraki_appliance_traffic_shaping_vpn_exclusions" "networks_appliance_t
   depends_on = [
     meraki_appliance_vlan.networks_appliance_vlans,
     meraki_appliance_single_lan.networks_appliance_single_lan,
+    meraki_appliance_site_to_site_vpn.networks_appliance_vpn_site_to_site_vpn,
+    meraki_appliance_third_party_vpn_peers.organizations_appliance_third_party_vpn_peers,
   ]
 }
 


### PR DESCRIPTION
## Summary

This PR addresses the dependency ordering issue reported in [netascode/nac-branch-terraform#72](https://wwwin-github.cisco.com/netascode/nac-branch-terraform/issues/72).

The Meraki appliance API enforces a strict requirement:

> *"Networks must meet minimum firmware requirements and have default VPN routes set in order to configure VPN exclusions"*

When `meraki_appliance_traffic_shaping_vpn_exclusions` is provisioned in the same Terraform run as the resources that establish the default VPN route, the apply fails because the exclusions are attempted before the VPN prerequisites are in place — forcing manual pipeline reruns.

## Root Cause

Two provisioning scenarios require explicit dependency ordering:

**Scenario 1 — Hub-based default route:**
`use_default_route = true` must be set in `meraki_appliance_site_to_site_vpn` before VPN exclusions can be configured.

**Scenario 2 — SSE alternative (third-party peers):**
`private_subnets` (e.g. `0.0.0.0/0`) must be set in `meraki_appliance_third_party_vpn_peers` before VPN exclusions can be applied.

## Changes

Added two explicit `depends_on` entries to `resource "meraki_appliance_traffic_shaping_vpn_exclusions" "networks_appliance_traffic_shaping_vpn_exclusions"` in `meraki_appliance.tf`:

- `meraki_appliance_site_to_site_vpn.networks_appliance_vpn_site_to_site_vpn` — ensures hub-based default route (`use_default_route`) is configured first
- `meraki_appliance_third_party_vpn_peers.organizations_appliance_third_party_vpn_peers` — ensures SSE-based default route (`private_subnets`) is configured first

This covers both provisioning paths (hub-based and SSE) and eliminates the need for manual pipeline reruns across initial branch configuration, migration toward SSE, and migration away from SSE.

## Test Plan

- [x] Verify `terraform apply` succeeds in a single run when `use_default_route = true` is set on a site-to-site VPN hub alongside VPN exclusions
- [x] Verify `terraform apply` succeeds in a single run when `private_subnets = "0.0.0.0/0"` is set on third-party VPN peers alongside VPN exclusions
- [x] Confirm no regression for networks without VPN exclusions configured

Addresses: https://wwwin-github.cisco.com/netascode/nac-branch-terraform/issues/72

🤖 Generated with [Claude Code](https://claude.com/claude-code)