### PR TITLE
fix: add required name attribute to adaptive policy group policy_objects

### DIFF
--- a/meraki_organization.tf
+++ b/meraki_organization.tf
@@ -284,7 +284,8 @@ locals {
           description     = try(adaptive_policy_group.description, local.defaults.meraki.domains.organizations.adaptive_policy.groups.description, null)
           policy_objects = try(adaptive_policy_group.policy_objects, null) == null ? null : [
             for policy_object in try(adaptive_policy_group.policy_objects, []) : {
-              id = try(local.organizations_policy_object_ids[format("%s/%s/%s", domain.name, organization.name, policy_object)], null)
+              id   = try(local.organizations_policy_object_ids[format("%s/%s/%s", domain.name, organization.name, policy_object)], null)
+              name = policy_object
             }
           ]
         }


### PR DESCRIPTION
## Error

```
│ Error: Incorrect attribute value type
│
│   on .terraform/modules/meraki/meraki_organization.tf line 312, in resource "meraki_organization_adaptive_policy_group" "organizations_adaptive_policy_groups":
│  312:   policy_objects  = each.value.policy_objects
│     ├────────────────
│     │ each.value.policy_objects is tuple with 1 element
│
│ Inappropriate value for attribute "policy_objects": element 0: attribute "name" is required.
```

## Root Cause

The `policy_objects` local block for `meraki_organization_adaptive_policy_group` was only setting the `id` attribute:

```hcl
for policy_object in try(adaptive_policy_group.policy_objects, []) : {
  id = try(local.organizations_policy_object_ids[format("%s/%s/%s", domain.name, organization.name, policy_object)], null)
}
```

Per the [CiscoDevNet/meraki provider documentation](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/organization_adaptive_policy_group#policy_objects-1), the `policy_objects` nested block requires **both** `id` and `name` attributes. The `name` field was missing, causing Terraform to reject the value at plan/apply time.

## Fix

Added `name = policy_object` to the map inside the `for` expression:

```hcl
for policy_object in try(adaptive_policy_group.policy_objects, []) : {
  id   = try(local.organizations_policy_object_ids[format("%s/%s/%s", domain.name, organization.name, policy_object)], null)
  name = policy_object
}
```

The `policy_objects` input is a list of policy object **name strings**, so the loop variable `policy_object` is already the name — the same value used to look up the ID from `local.organizations_policy_object_ids`. No changes to calling configs or the data model are required.

## Test plan
- [x] `terraform plan` no longer errors on `meraki_organization_adaptive_policy_group` resources that have `policy_objects` defined

🤖 Generated with [Claude Code](https://claude.com/claude-code)