### PR TITLE
Add new switch routing interface parameters from Meraki Early Access API

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ module "meraki" {
 | [meraki_switch_ports.devices_switch_ports](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/switch_ports) | resource |
 | [meraki_switch_qos_rule.networks_switch_qos_rules](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/switch_qos_rule) | resource |
 | [meraki_switch_qos_rule_order.networks_switch_qos_rules_order](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/switch_qos_rule_order) | resource |
-| [meraki_switch_routing_interface.devices_switch_routing_interfaces](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/switch_routing_interface) | resource |
+| [meraki_switch_routing_interface.devices_switch_routing_interfaces_first](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/switch_routing_interface) | resource |
+| [meraki_switch_routing_interface.devices_switch_routing_interfaces_not_first](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/switch_routing_interface) | resource |
 | [meraki_switch_routing_interface_dhcp.devices_switch_routing_interfaces_dhcp](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/switch_routing_interface_dhcp) | resource |
 | [meraki_switch_routing_multicast.networks_switch_routing_multicast](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/switch_routing_multicast) | resource |
 | [meraki_switch_routing_multicast_rendezvous_point.networks_switch_routing_multicast_rendezvous_points](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/switch_routing_multicast_rendezvous_point) | resource |

--- a/meraki_devices.tf
+++ b/meraki_devices.tf
@@ -263,16 +263,32 @@ locals {
               ipv6_prefix                      = try(switch_routing_interface.ipv6.prefix, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.ipv6.prefix, null)
               ipv6_address                     = try(switch_routing_interface.ipv6.address, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.ipv6.address, null)
               ipv6_gateway                     = try(switch_routing_interface.ipv6.gateway, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.ipv6.gateway, null)
+              ipv6_static_v6_dns1              = try(switch_routing_interface.ipv6.static_v6_dns1, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.ipv6.static_v6_dns1, null)
+              ipv6_static_v6_dns2              = try(switch_routing_interface.ipv6.static_v6_dns2, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.ipv6.static_v6_dns2, null)
+              static_v4_dns1                   = try(switch_routing_interface.static_v4_dns1, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.static_v4_dns1, null)
+              static_v4_dns2                   = try(switch_routing_interface.static_v4_dns2, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.static_v4_dns2, null)
+              uplink_v4                        = try(switch_routing_interface.uplink_v4, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.uplink_v4, null)
+              uplink_v6                        = try(switch_routing_interface.uplink_v6, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.uplink_v6, null)
             }
           ]
         ]
       ]
     ]
   ])
+  devices_switch_routing_interfaces_first = [
+    for routing_interface in local.devices_switch_routing_interfaces :
+    routing_interface
+    if routing_interface.default_gateway != null || routing_interface.uplink_v4 != null || routing_interface.uplink_v6 != null
+  ]
+  devices_switch_routing_interfaces_not_first = [
+    for routing_interface in local.devices_switch_routing_interfaces :
+    routing_interface
+    if routing_interface.default_gateway == null && routing_interface.uplink_v4 == null && routing_interface.uplink_v6 == null
+  ]
 }
 
-resource "meraki_switch_routing_interface" "devices_switch_routing_interfaces" {
-  for_each                         = { for v in local.devices_switch_routing_interfaces : v.key => v }
+resource "meraki_switch_routing_interface" "devices_switch_routing_interfaces_first" {
+  for_each                         = { for v in local.devices_switch_routing_interfaces_first : v.key => v }
   serial                           = each.value.serial
   name                             = each.value.name
   subnet                           = each.value.subnet
@@ -287,6 +303,48 @@ resource "meraki_switch_routing_interface" "devices_switch_routing_interfaces" {
   ipv6_prefix                      = each.value.ipv6_prefix
   ipv6_address                     = each.value.ipv6_address
   ipv6_gateway                     = each.value.ipv6_gateway
+  ipv6_static_v6_dns1              = each.value.ipv6_static_v6_dns1
+  ipv6_static_v6_dns2              = each.value.ipv6_static_v6_dns2
+  static_v4_dns1                   = each.value.static_v4_dns1
+  static_v4_dns2                   = each.value.static_v4_dns2
+  uplink_v4                        = each.value.uplink_v4
+  uplink_v6                        = each.value.uplink_v6
+}
+resource "meraki_switch_routing_interface" "devices_switch_routing_interfaces_not_first" {
+  for_each                         = { for v in local.devices_switch_routing_interfaces_not_first : v.key => v }
+  serial                           = each.value.serial
+  name                             = each.value.name
+  subnet                           = each.value.subnet
+  interface_ip                     = each.value.interface_ip
+  multicast_routing                = each.value.multicast_routing
+  vlan_id                          = each.value.vlan_id
+  default_gateway                  = each.value.default_gateway
+  ospf_settings_area               = each.value.ospf_settings_area
+  ospf_settings_cost               = each.value.ospf_settings_cost
+  ospf_settings_is_passive_enabled = each.value.ospf_settings_is_passive_enabled
+  ipv6_assignment_mode             = each.value.ipv6_assignment_mode
+  ipv6_prefix                      = each.value.ipv6_prefix
+  ipv6_address                     = each.value.ipv6_address
+  ipv6_gateway                     = each.value.ipv6_gateway
+  ipv6_static_v6_dns1              = each.value.ipv6_static_v6_dns1
+  ipv6_static_v6_dns2              = each.value.ipv6_static_v6_dns2
+  static_v4_dns1                   = each.value.static_v4_dns1
+  static_v4_dns2                   = each.value.static_v4_dns2
+  uplink_v4                        = each.value.uplink_v4
+  uplink_v6                        = each.value.uplink_v6
+  depends_on = [
+    meraki_switch_routing_interface.devices_switch_routing_interfaces_first,
+  ]
+}
+
+locals {
+  devices_switch_routing_interface_ids = {
+    for routing_interface in local.devices_switch_routing_interfaces :
+    routing_interface.key =>
+    (routing_interface.default_gateway != null || routing_interface.uplink_v4 != null || routing_interface.uplink_v6 != null) ?
+    meraki_switch_routing_interface.devices_switch_routing_interfaces_first[routing_interface.key].id :
+    meraki_switch_routing_interface.devices_switch_routing_interfaces_not_first[routing_interface.key].id
+  }
 }
 
 locals {
@@ -298,7 +356,7 @@ locals {
             for switch_routing_interface in try(device.switch_routing_interfaces, []) : {
               key                    = format("%s/%s/%s/%s/%s", domain.name, organization.name, network.name, device.name, switch_routing_interface.name)
               serial                 = meraki_device.devices[format("%s/%s/%s/%s", domain.name, organization.name, network.name, device.name)].serial
-              interface_id           = meraki_switch_routing_interface.devices_switch_routing_interfaces[format("%s/%s/%s/%s/%s", domain.name, organization.name, network.name, device.name, switch_routing_interface.name)].id
+              interface_id           = local.devices_switch_routing_interface_ids[format("%s/%s/%s/%s/%s", domain.name, organization.name, network.name, device.name, switch_routing_interface.name)]
               dhcp_mode              = try(switch_routing_interface.dhcp.dhcp_mode, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.dhcp_mode, null)
               dhcp_relay_server_ips  = try(switch_routing_interface.dhcp.dhcp_relay_server_ips, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.dhcp_relay_server_ips, null)
               dhcp_lease_time        = try(switch_routing_interface.dhcp.dhcp_lease_time, local.defaults.meraki.domains.organizations.networks.devices.switch_routing_interfaces.dhcp.dhcp_lease_time, null)
@@ -384,7 +442,8 @@ resource "meraki_switch_routing_static_route" "devices_switch_routing_static_rou
   advertise_via_ospf_enabled      = each.value.advertise_via_ospf_enabled
   prefer_over_ospf_routes_enabled = each.value.prefer_over_ospf_routes_enabled
   depends_on = [
-    meraki_switch_routing_interface.devices_switch_routing_interfaces,
+    meraki_switch_routing_interface.devices_switch_routing_interfaces_first,
+    meraki_switch_routing_interface.devices_switch_routing_interfaces_not_first,
   ]
 }
 

--- a/meraki_switches.tf
+++ b/meraki_switches.tf
@@ -695,6 +695,12 @@ locals {
               ipv6_prefix                      = try(routing_interface.ipv6.prefix, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.ipv6.prefix, null)
               ipv6_address                     = try(routing_interface.ipv6.address, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.ipv6.address, null)
               ipv6_gateway                     = try(routing_interface.ipv6.gateway, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.ipv6.gateway, null)
+              ipv6_static_v6_dns1              = try(routing_interface.ipv6.static_v6_dns1, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.ipv6.static_v6_dns1, null)
+              ipv6_static_v6_dns2              = try(routing_interface.ipv6.static_v6_dns2, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.ipv6.static_v6_dns2, null)
+              static_v4_dns1                   = try(routing_interface.static_v4_dns1, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.static_v4_dns1, null)
+              static_v4_dns2                   = try(routing_interface.static_v4_dns2, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.static_v4_dns2, null)
+              uplink_v4                        = try(routing_interface.uplink_v4, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.uplink_v4, null)
+              uplink_v6                        = try(routing_interface.uplink_v6, local.defaults.meraki.domains.organizations.networks.switch_stacks.routing_interfaces.uplink_v6, null)
             }
           ]
         ]
@@ -704,12 +710,12 @@ locals {
   networks_switch_stacks_routing_interfaces_first = [
     for routing_interface in local.networks_switch_stacks_routing_interfaces :
     routing_interface
-    if routing_interface.default_gateway != null
+    if routing_interface.default_gateway != null || routing_interface.uplink_v4 != null || routing_interface.uplink_v6 != null
   ]
   networks_switch_stacks_routing_interfaces_not_first = [
     for routing_interface in local.networks_switch_stacks_routing_interfaces :
     routing_interface
-    if routing_interface.default_gateway == null
+    if routing_interface.default_gateway == null && routing_interface.uplink_v4 == null && routing_interface.uplink_v6 == null
   ]
 }
 
@@ -730,6 +736,12 @@ resource "meraki_switch_stack_routing_interface" "networks_switch_stacks_routing
   ipv6_prefix                      = each.value.ipv6_prefix
   ipv6_address                     = each.value.ipv6_address
   ipv6_gateway                     = each.value.ipv6_gateway
+  ipv6_static_v6_dns1              = each.value.ipv6_static_v6_dns1
+  ipv6_static_v6_dns2              = each.value.ipv6_static_v6_dns2
+  static_v4_dns1                   = each.value.static_v4_dns1
+  static_v4_dns2                   = each.value.static_v4_dns2
+  uplink_v4                        = each.value.uplink_v4
+  uplink_v6                        = each.value.uplink_v6
   depends_on = [
     meraki_network_device_claim.networks_devices_claim,
   ]
@@ -751,6 +763,12 @@ resource "meraki_switch_stack_routing_interface" "networks_switch_stacks_routing
   ipv6_prefix                      = each.value.ipv6_prefix
   ipv6_address                     = each.value.ipv6_address
   ipv6_gateway                     = each.value.ipv6_gateway
+  ipv6_static_v6_dns1              = each.value.ipv6_static_v6_dns1
+  ipv6_static_v6_dns2              = each.value.ipv6_static_v6_dns2
+  static_v4_dns1                   = each.value.static_v4_dns1
+  static_v4_dns2                   = each.value.static_v4_dns2
+  uplink_v4                        = each.value.uplink_v4
+  uplink_v6                        = each.value.uplink_v6
   depends_on = [
     meraki_switch_stack_routing_interface.networks_switch_stacks_routing_interfaces_first,
   ]
@@ -760,7 +778,7 @@ locals {
   networks_switch_stacks_routing_interface_ids = {
     for routing_interface in local.networks_switch_stacks_routing_interfaces :
     routing_interface.key =>
-    routing_interface.default_gateway != null ?
+    (routing_interface.default_gateway != null || routing_interface.uplink_v4 != null || routing_interface.uplink_v6 != null) ?
     meraki_switch_stack_routing_interface.networks_switch_stacks_routing_interfaces_first[routing_interface.key].id :
     meraki_switch_stack_routing_interface.networks_switch_stacks_routing_interfaces_not_first[routing_interface.key].id
   }


### PR DESCRIPTION
## Summary

Added new switch routing interface parameters published in the [Meraki Early Access API](https://developer.cisco.com/meraki/api-v1/api-reference-early-access-api-products-switch-configure-routing-interfaces-create-device-switch-routing-interface/) for both device-level (`meraki_devices.tf`) and switch stack (`meraki_switches.tf`) routing interfaces.

### New parameters added

**Top-level fields** (both `meraki_switch_routing_interface` and `meraki_switch_stack_routing_interface`):
- `static_v4_dns1` — Primary IPv4 DNS server address
- `static_v4_dns2` — Secondary IPv4 DNS server address
- `uplink_v4` — When true, interface is used as static IPv4 uplink
- `uplink_v6` — When true, interface is used as static IPv6 uplink

**IPv6 sub-fields** (both resources):
- `ipv6_static_v6_dns1` — Primary IPv6 DNS server address
- `ipv6_static_v6_dns2` — Secondary IPv6 DNS server address

### First / not-first batch ordering (`meraki_devices.tf`)

Implemented the same two-batch creation pattern that already exists for switch stack routing interfaces:
- `devices_switch_routing_interfaces_first` — interfaces where `default_gateway`, `uplink_v4`, or `uplink_v6` is set; created first
- `devices_switch_routing_interfaces_not_first` — all remaining interfaces; depends on the first batch
- Added `devices_switch_routing_interface_ids` local to resolve the correct resource ID for each interface
- Updated DHCP `interface_id` lookup and `depends_on` to reference both new resources

### Updated batch condition (`meraki_switches.tf`)

Extended the existing `networks_switch_stacks_routing_interfaces_first` / `_not_first` split condition from checking only `default_gateway` to also include `uplink_v4` and `uplink_v6`, so any interface acting as an uplink is always provisioned in the first batch.

## Test plan
- [x] `terraform plan` and `terraform apply` validated against live environment
- [x] IPv4-only uplink, IPv6-only non-uplink, IPv4-only non-uplink, and dual-stack uplink all tested successfully
- [x] First/not-first batch ordering confirmed working for device routing interfaces
- [x] Catalyst IOS-XE specific uplink scenarios to be validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)