### PR TITLE
fix: ensure Default VLAN profile is created before non-default profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ module "meraki" {
 | [meraki_network_settings.networks_settings](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_settings) | resource |
 | [meraki_network_snmp.networks_snmp](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_snmp) | resource |
 | [meraki_network_syslog_servers.networks_syslog_servers](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_syslog_servers) | resource |
-| [meraki_network_vlan_profile.networks_vlan_profiles](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_vlan_profile) | resource |
+| [meraki_network_vlan_profile.networks_vlan_profiles_default](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_vlan_profile) | resource |
+| [meraki_network_vlan_profile.networks_vlan_profiles_not_default](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_vlan_profile) | resource |
 | [meraki_network_webhook_http_server.networks_webhooks_http_servers](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_webhook_http_server) | resource |
 | [meraki_network_webhook_payload_template.networks_webhooks_payload_templates](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_webhook_payload_template) | resource |
 | [meraki_organization.organizations](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/organization) | resource |

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -250,15 +250,37 @@ locals {
       ]
     ]
   ])
+  networks_vlan_profiles_default = [
+    for vlan_profile in local.networks_vlan_profiles :
+    vlan_profile
+    if vlan_profile.iname == "Default"
+  ]
+  networks_vlan_profiles_not_default = [
+    for vlan_profile in local.networks_vlan_profiles :
+    vlan_profile
+    if vlan_profile.iname != "Default"
+  ]
 }
 
-resource "meraki_network_vlan_profile" "networks_vlan_profiles" {
-  for_each    = { for v in local.networks_vlan_profiles : v.key => v }
+resource "meraki_network_vlan_profile" "networks_vlan_profiles_default" {
+  for_each    = { for v in local.networks_vlan_profiles_default : v.key => v }
   network_id  = each.value.network_id
   name        = each.value.name
   vlan_names  = each.value.vlan_names
   vlan_groups = each.value.vlan_groups
   iname       = each.value.iname
+}
+
+resource "meraki_network_vlan_profile" "networks_vlan_profiles_not_default" {
+  for_each    = { for v in local.networks_vlan_profiles_not_default : v.key => v }
+  network_id  = each.value.network_id
+  name        = each.value.name
+  vlan_names  = each.value.vlan_names
+  vlan_groups = each.value.vlan_groups
+  iname       = each.value.iname
+  depends_on = [
+    meraki_network_vlan_profile.networks_vlan_profiles_default,
+  ]
 }
 
 locals {


### PR DESCRIPTION
## Issue

When applying VLAN profiles, the Meraki API returns an HTTP 400 error if a non-default VLAN profile references named VLANs that have not yet been registered in the **Default** profile:

```
Error: Client Error
Failed to configure object (POST/PUT), got error: HTTP Request failed:
StatusCode 400, JSON error: ["invalid named VLANs: CORP.
Please add them to the default profile first."]
```

This happens because all VLAN profiles were managed under a single resource (`meraki_network_vlan_profile.networks_vlan_profiles`), which allows Terraform to create them in any order — including non-default profiles before the Default one.

## Plan

The Default VLAN profile (where `iname == "Default"`) must always be created/updated **before** any other VLAN profiles. Non-default profiles must explicitly depend on the Default profile being in place first.

## Fix

Split the single `meraki_network_vlan_profile.networks_vlan_profiles` resource into two:

- **`networks_vlan_profiles_default`** — contains only profiles where `iname == "Default"`; created first with no additional dependencies.
- **`networks_vlan_profiles_not_default`** — contains all other profiles; has `depends_on = [meraki_network_vlan_profile.networks_vlan_profiles_default]` to guarantee ordering.

Two corresponding locals (`networks_vlan_profiles_default` and `networks_vlan_profiles_not_default`) filter the existing `networks_vlan_profiles` list by `iname`. The `README.md` resource table was updated to reflect the renamed resources.

> **Note for adopters:** Existing state entries under the old resource name (`networks_vlan_profiles`) must be migrated with `terraform state mv` before applying to avoid destroy/recreate of existing profiles.

example:
```
% terraform state list | grep vlan_profile          
module.meraki.meraki_network_vlan_profile.networks_vlan_profiles["EU/CX Meraki Lab/Unified Branch 3/Default Profile"]
module.meraki.meraki_network_vlan_profile.networks_vlan_profiles["EU/CX Meraki Lab/Unified Branch 3/Yahoo"]

% terraform state mv 'module.meraki.meraki_network_vlan_profile.networks_vlan_profiles["EU/CX Meraki Lab/Unified Branch 3/Default Profile"]' 'module.meraki.meraki_network_vlan_profile.networks_vlan_profiles_default["EU/CX Meraki Lab/Unified Branch 3/Default Profile"]'
% terraform state mv 'module.meraki.meraki_network_vlan_profile.networks_vlan_profiles["EU/CX Meraki Lab/Unified Branch 3/Yahoo"]' 'module.meraki.meraki_network_vlan_profile.networks_vlan_profiles_not_default["EU/CX Meraki Lab/Unified Branch 3/Yahoo"]'
```