### PR TITLE
chore: update CHANGELOG for 0.8.2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## 0.8.2
+
+Minimum Required Meraki Provider:
+
+- Raise the minimum required meraki provider version to `1.11.0` in `versions.tf`. This is required for the switch routing interface attributes added in `0.8.0` (`ipv6_static_v6_dns{1,2}`, `static_v4_dns{1,2}`, `uplink_v{4,6}` on `devices_switch_routing_interfaces` and `networks_switch_stacks_routing_interfaces`). Consumers pinned to an older provider must upgrade. (https://github.com/netascode/terraform-meraki-nac-meraki/pull/168)
+
 ## 0.8.1
 
 Bug Fixes:


### PR DESCRIPTION
Adds the changelog entry for the upcoming `0.8.2` release.

  `0.8.2` ships a single change — #168, which raises the minimum required meraki provider version to `1.11.0` so that the switch routing interface attributes added in       
  `0.8.0` (`ipv6_static_v6_dns{1,2}`, `static_v4_dns{1,2}`, `uplink_v{4,6}` on `devices_switch_routing_interfaces` and `networks_switch_stacks_routing_interfaces`) resolve
  against the provider. Without this floor, consumers on `0.8.1` pinned to an older provider hit "unknown attribute" errors at plan time.                                 