### PR TITLE
Fix passing required lists of dicts

### DIFF
--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -133,7 +133,7 @@ locals {
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-          rules = try(network.appliance.firewall.inbound_firewall_rules.rules, null) == null ? null : [
+          rules = [
             for rule in try(network.appliance.firewall.inbound_firewall_rules.rules, []) : {
               comment  = try(rule.comment, local.defaults.meraki.domains.organizations.networks.appliance.firewall.inbound_firewall_rules.rules.comment, null)
               policy   = try(rule.policy, local.defaults.meraki.domains.organizations.networks.appliance.firewall.inbound_firewall_rules.rules.policy, null)
@@ -257,7 +257,7 @@ locals {
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-          rules = try(network.appliance.firewall.l7_firewall_rules, null) == null ? null : [
+          rules = [
             for appliance_firewall_l7_firewall_rule in try(network.appliance.firewall.l7_firewall_rules, []) : {
               policy          = try(appliance_firewall_l7_firewall_rule.policy, local.defaults.meraki.domains.organizations.networks.appliance.firewall.l7_firewall_rules.policy, null)
               type            = try(appliance_firewall_l7_firewall_rule.type, local.defaults.meraki.domains.organizations.networks.appliance.firewall.l7_firewall_rules.type, null)
@@ -287,11 +287,11 @@ locals {
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-          rules = try(network.appliance.firewall.one_to_many_nat_rules, null) == null ? null : [
+          rules = [
             for appliance_firewall_one_to_many_nat_rule in try(network.appliance.firewall.one_to_many_nat_rules, []) : {
               public_ip = try(appliance_firewall_one_to_many_nat_rule.public_ip, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_many_nat_rules.public_ip, null)
               uplink    = try(appliance_firewall_one_to_many_nat_rule.uplink, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_many_nat_rules.uplink, null)
-              port_rules = try(appliance_firewall_one_to_many_nat_rule.port_rules, null) == null ? null : [
+              port_rules = [
                 for port_rule in try(appliance_firewall_one_to_many_nat_rule.port_rules, []) : {
                   name        = try(port_rule.name, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_many_nat_rules.port_rules.name, null)
                   protocol    = try(port_rule.protocol, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_many_nat_rules.port_rules.protocol, null)
@@ -325,7 +325,7 @@ locals {
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-          rules = try(network.appliance.firewall.one_to_one_nat_rules, null) == null ? null : [
+          rules = [
             for appliance_firewall_one_to_one_nat_rule in try(network.appliance.firewall.one_to_one_nat_rules, []) : {
               name      = try(appliance_firewall_one_to_one_nat_rule.name, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_one_nat_rules.name, null)
               public_ip = try(appliance_firewall_one_to_one_nat_rule.public_ip, local.defaults.meraki.domains.organizations.networks.appliance.firewall.one_to_one_nat_rules.public_ip, null)
@@ -362,7 +362,7 @@ locals {
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-          rules = try(network.appliance.firewall.port_forwarding_rules, null) == null ? null : [
+          rules = [
             for appliance_firewall_port_forwarding_rule in try(network.appliance.firewall.port_forwarding_rules, []) : {
               name        = try(appliance_firewall_port_forwarding_rule.name, local.defaults.meraki.domains.organizations.networks.appliance.firewall.port_forwarding_rules.name, null)
               lan_ip      = try(appliance_firewall_port_forwarding_rule.lan_ip, local.defaults.meraki.domains.organizations.networks.appliance.firewall.port_forwarding_rules.lan_ip, null)

--- a/meraki_organization.tf
+++ b/meraki_organization.tf
@@ -636,7 +636,7 @@ locals {
       for organization in try(domain.organizations, []) : {
         key             = format("%s/%s", domain.name, organization.name)
         organization_id = local.organization_ids[format("%s/%s", domain.name, organization.name)]
-        rules = try(organization.appliance.vpn_firewall_rules.rules, null) == null ? null : [
+        rules = [
           for rule in try(organization.appliance.vpn_firewall_rules.rules, []) : {
             comment        = try(rule.comment, local.defaults.meraki.domains.organizations.appliance.vpn_firewall_rules.rules.comment, null)
             policy         = try(rule.policy, local.defaults.meraki.domains.organizations.appliance.vpn_firewall_rules.rules.policy, null)


### PR DESCRIPTION
The general rule for lists of dicts is:
- pass `null` (equivalent to not passing the field) when the field is missing or `null` in the YAML;
- pass `[]` when the field is `[]` in the YAML.

If the field is required by the provider,
passing `null` would fail,
so the rule is to pass `[]` instead
to allow not specifying the empty list in the YAML.

Some fields were refactored manually (before the generator was used), breaking the pattern.
Example: `networks_appliance_firewall_inbound_firewall_rules.rules`: https://github.com/netascode/terraform-meraki-nac-meraki/commit/1b2c90fb7e6eaad07e88fc18dfdfcbdd4c1b11ce#diff-649a645aa2b59f9def97a9c3ba97df93fa2e802fa35a94328d993e7f35a94ac5R62

Change all such fields to match the generator.

The following changes fix a bug:
- `networks.appliance.firewall.inbound_firewall_rules.rules`;
- `networks.appliance.firewall.one_to_many_nat_rules.port_rules` (flattened resource's nested field);
- `organizations.appliance.vpn_firewall_rules.rules`.

The following fixes are cosmetic -
these resources are flattened (resource YAML path = field YAML path), so the resource is not created
(thus not triggering the provider's requirement)
if the field is not specified in the YAML:
- `networks.appliance.firewall.l7_firewall_rules`;
- `networks.appliance.firewall.one_to_many_nat_rules`;
- `networks.appliance.firewall.one_to_one_nat_rules`;
- `networks.appliance.firewall.port_forwarding_rules`.