### PR TITLE
feat: Network Firmware Upgrades and Downgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ module "meraki" {
 | [meraki_device_management_interface.devices_management_interface](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/device_management_interface) | resource |
 | [meraki_network.organizations_networks](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network) | resource |
 | [meraki_network_device_claim.networks_devices_claim](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_device_claim) | resource |
-| [meraki_network_firmware_upgrades.networks_firmware_upgrades](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_firmware_upgrades) | resource |
-| [meraki_network_firmware_upgrades_rollback.networks_firmware_rollbacks](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_firmware_upgrades_rollback) | resource |
+| [meraki_network_firmware_upgrades.networks_firmware](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_firmware_upgrades) | resource |
+| [meraki_network_firmware_upgrades_rollback.networks_firmware_downgrade](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_firmware_upgrades_rollback) | resource |
 | [meraki_network_floor_plan.networks_floor_plans](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_floor_plan) | resource |
 | [meraki_network_group_policy.networks_group_policies](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_group_policy) | resource |
 | [meraki_network_netflow.networks_netflow](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_netflow) | resource |
@@ -186,7 +186,7 @@ module "meraki" {
 | [meraki_wireless_ssid_splash_settings.networks_wireless_ssids_splash_settings](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/wireless_ssid_splash_settings) | resource |
 | [meraki_wireless_ssid_traffic_shaping_rules.networks_wireless_ssids_traffic_shaping_rules](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/wireless_ssid_traffic_shaping_rules) | resource |
 | [meraki_network.organizations_networks](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/data-sources/network) | data source |
-| [meraki_network_firmware_upgrades.networks_firmware_data](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/data-sources/network_firmware_upgrades) | data source |
+| [meraki_network_firmware_upgrades.networks_firmware_available_versions](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/data-sources/network_firmware_upgrades) | data source |
 | [meraki_organization.organizations](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/data-sources/organization) | data source |
 | [meraki_organization_adaptive_policy_group.organizations_adaptive_policy_groups](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/data-sources/organization_adaptive_policy_group) | data source |
 | [meraki_organization_policy_object.organizations_policy_objects](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/data-sources/organization_policy_object) | data source |

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ module "meraki" {
 | [meraki_device_management_interface.devices_management_interface](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/device_management_interface) | resource |
 | [meraki_network.organizations_networks](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network) | resource |
 | [meraki_network_device_claim.networks_devices_claim](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_device_claim) | resource |
+| [meraki_network_firmware_upgrades.networks_firmware_upgrades](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_firmware_upgrades) | resource |
+| [meraki_network_firmware_upgrades_rollback.networks_firmware_rollbacks](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_firmware_upgrades_rollback) | resource |
 | [meraki_network_floor_plan.networks_floor_plans](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_floor_plan) | resource |
 | [meraki_network_group_policy.networks_group_policies](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_group_policy) | resource |
 | [meraki_network_netflow.networks_netflow](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_netflow) | resource |
@@ -184,6 +186,7 @@ module "meraki" {
 | [meraki_wireless_ssid_splash_settings.networks_wireless_ssids_splash_settings](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/wireless_ssid_splash_settings) | resource |
 | [meraki_wireless_ssid_traffic_shaping_rules.networks_wireless_ssids_traffic_shaping_rules](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/wireless_ssid_traffic_shaping_rules) | resource |
 | [meraki_network.organizations_networks](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/data-sources/network) | data source |
+| [meraki_network_firmware_upgrades.networks_firmware_data](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/data-sources/network_firmware_upgrades) | data source |
 | [meraki_organization.organizations](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/data-sources/organization) | data source |
 | [meraki_organization_adaptive_policy_group.organizations_adaptive_policy_groups](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/data-sources/organization_adaptive_policy_group) | data source |
 | [meraki_organization_policy_object.organizations_policy_objects](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/data-sources/organization_policy_object) | data source |

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -768,7 +768,7 @@ locals {
             # See upgrade locals above — Z is required by the API but does not mean UTC.
             time                = try("${product_cfg.next_downgrade.local_time}Z", null)
             to_version_id       = try(product_cfg.next_downgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)][product][product_cfg.next_downgrade.to_version]
-            predownload_enabled = product == "wireless" ? try(product_cfg.next_downgrade.pre_download, null) : null
+            predownload_enabled = product == "wireless" ? try(product_cfg.next_downgrade.pre_download, local.defaults.meraki.domains.organizations.networks.firmware.downgrade.products.wireless.next_downgrade.pre_download, null) : null
             reasons = [
               for reason in try(product_cfg.next_downgrade.reasons, []) : {
                 category = try(reason.category, null)

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -679,7 +679,15 @@ locals {
           network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
 
           # The API requires capitalized day names (e.g. "Sun", "Monday"). YAML stores lowercase; title() converts here.
-          upgrade_window_day_of_week = try(title(network.firmware.automatic_upgrade_window.day_of_week), title(local.defaults.meraki.domains.organizations.networks.firmware.automatic_upgrade_window.day_of_week), null)
+          upgrade_window_day_of_week = try(network.firmware.automatic_upgrade_window.day_of_week, local.defaults.meraki.domains.organizations.networks.firmware.automatic_upgrade_window.day_of_week, null) == null ? null : {
+            sunday    = "Sun"
+            monday    = "Mon"
+            tuesday   = "Tue"
+            wednesday = "Wed"
+            thursday  = "Thu"
+            friday    = "Fri"
+            saturday  = "Sat"
+          }[try(network.firmware.automatic_upgrade_window.day_of_week, local.defaults.meraki.domains.organizations.networks.firmware.automatic_upgrade_window.day_of_week)]
           upgrade_window_hour_of_day = try(network.firmware.automatic_upgrade_window.hour_of_day, local.defaults.meraki.domains.organizations.networks.firmware.automatic_upgrade_window.hour_of_day, null)
 
           products_appliance_participate_in_next_beta_release = try(network.firmware.upgrade.products.appliance.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.appliance.participate_in_next_beta_release, null)

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -642,22 +642,27 @@ data "meraki_network_firmware_upgrades" "networks_firmware_available_versions" {
   network_id = each.value.network_id
 }
 
-# Flat map: {"domain/org/network/product/short_name" → id} — consistent with other single-level ID lookups; resolves YAML version names to numeric IDs
+# A map from YAML product names + version names to numeric version IDs from the network's datasource:
+# { "domain_name/organization_name/network_name/product/version_short_name" -> version_id }
 locals {
-  networks_firmware_version_maps = { for item in flatten([
-    for fw_upgrade_cfg in local.networks_firmware_available_version_lookups : [
-      [for v in try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_appliance_available_versions, []) :
-      { key = "${fw_upgrade_cfg.key}/appliance/${v.short_name}", id = v.id }],
-      [for v in try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_cellular_gateway_available_versions, []) :
-      { key = "${fw_upgrade_cfg.key}/cellular_gateway/${v.short_name}", id = v.id }],
-      [for v in try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_available_versions, []) :
-      { key = "${fw_upgrade_cfg.key}/switch/${v.short_name}", id = v.id }],
-      [for v in try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_catalyst_available_versions, []) :
-      { key = "${fw_upgrade_cfg.key}/switch_catalyst/${v.short_name}", id = v.id }],
-      [for v in try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_wireless_available_versions, []) :
-      { key = "${fw_upgrade_cfg.key}/wireless/${v.short_name}", id = v.id }],
-    ]
-  ]) : item.key => item.id }
+  networks_firmware_version_ids = {
+    for v in flatten([
+      for network in local.networks_firmware_available_version_lookups : [
+        for product, available_versions in {
+          "appliance"        = try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[network.key].products_appliance_available_versions, [])
+          "cellular_gateway" = try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[network.key].products_cellular_gateway_available_versions, [])
+          "switch"           = try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[network.key].products_switch_available_versions, [])
+          "switch_catalyst"  = try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[network.key].products_switch_catalyst_available_versions, [])
+          "wireless"         = try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[network.key].products_wireless_available_versions, [])
+          } : [
+          for version in available_versions : {
+            key = format("%s/%s/%s", network.key, product, version.short_name)
+            id  = version.id
+          }
+        ]
+      ]
+    ]) : v.key => v.id
+  }
 }
 
 locals {
@@ -682,26 +687,26 @@ locals {
 
           products_appliance_participate_in_next_beta_release = try(network.firmware.upgrade.products.appliance.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.appliance.participate_in_next_beta_release, null)
           products_appliance_next_upgrade_time                = try("${network.firmware.upgrade.products.appliance.next_upgrade.local_time}Z", null)
-          products_appliance_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.appliance.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s/appliance/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.appliance.next_upgrade.to_version)]
+          products_appliance_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.appliance.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_ids[format("%s/%s/%s/appliance/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.appliance.next_upgrade.to_version)]
 
           products_cellular_gateway_participate_in_next_beta_release = try(network.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, null)
           products_cellular_gateway_next_upgrade_time                = try("${network.firmware.upgrade.products.cellular_gateway.next_upgrade.local_time}Z", null)
-          products_cellular_gateway_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s/cellular_gateway/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version)]
+          products_cellular_gateway_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_ids[format("%s/%s/%s/cellular_gateway/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version)]
 
           products_switch_participate_in_next_beta_release = try(network.firmware.upgrade.products.switch.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch.participate_in_next_beta_release, null)
           # The API requires a trailing Z in the time field, but this is not true UTC — the time is interpreted in
           # the network's configured timezone. YAML stores local_time without Z; the module appends it here.
           products_switch_next_upgrade_time          = try("${network.firmware.upgrade.products.switch.next_upgrade.local_time}Z", null)
-          products_switch_next_upgrade_to_version_id = try(network.firmware.upgrade.products.switch.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s/switch/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.switch.next_upgrade.to_version)]
+          products_switch_next_upgrade_to_version_id = try(network.firmware.upgrade.products.switch.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_ids[format("%s/%s/%s/switch/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.switch.next_upgrade.to_version)]
 
           products_switch_catalyst_participate_in_next_beta_release = try(network.firmware.upgrade.products.switch_catalyst.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch_catalyst.participate_in_next_beta_release, null)
           products_switch_catalyst_next_upgrade_time                = try("${network.firmware.upgrade.products.switch_catalyst.next_upgrade.local_time}Z", null)
-          products_switch_catalyst_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s/switch_catalyst/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version)]
+          products_switch_catalyst_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_ids[format("%s/%s/%s/switch_catalyst/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version)]
 
           products_wireless_participate_in_next_beta_release = try(network.firmware.upgrade.products.wireless.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.participate_in_next_beta_release, null)
           products_wireless_next_upgrade_time                = try("${network.firmware.upgrade.products.wireless.next_upgrade.local_time}Z", null)
           products_wireless_next_upgrade_predownload_enabled = try(network.firmware.upgrade.products.wireless.next_upgrade.pre_download, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.next_upgrade.pre_download, null)
-          products_wireless_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.wireless.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s/wireless/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.wireless.next_upgrade.to_version)]
+          products_wireless_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.wireless.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_ids[format("%s/%s/%s/wireless/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.wireless.next_upgrade.to_version)]
           } if(
           try(network.firmware.automatic_upgrade_window, null) != null ||
           try(network.firmware.upgrade, null) != null
@@ -757,7 +762,7 @@ locals {
             }[product]
             # See upgrade locals above — Z is required by the API but does not mean UTC.
             time                = try("${product_cfg.next_downgrade.local_time}Z", null)
-            to_version_id       = try(product_cfg.next_downgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s/%s/%s", domain.name, organization.name, network.name, product, product_cfg.next_downgrade.to_version)]
+            to_version_id       = try(product_cfg.next_downgrade.to_version, null) == null ? null : local.networks_firmware_version_ids[format("%s/%s/%s/%s/%s", domain.name, organization.name, network.name, product, product_cfg.next_downgrade.to_version)]
             predownload_enabled = product == "wireless" ? try(product_cfg.next_downgrade.pre_download, local.defaults.meraki.domains.organizations.networks.firmware.downgrade.products.wireless.next_downgrade.pre_download, null) : null
             reasons = [
               for reason in try(product_cfg.next_downgrade.reasons, []) : {

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -642,31 +642,16 @@ data "meraki_network_firmware_upgrades" "networks_firmware_available_versions" {
   network_id = each.value.network_id
 }
 
-# Per-network map: {product → {short_name → id}} — resolves YAML version names to numeric IDs
+# Per-network map: {"product/short_name" → id} — resolves YAML version names to numeric IDs
 locals {
   networks_firmware_version_maps = {
-    for fw_upgrade_cfg in local.networks_firmware_available_version_lookups : fw_upgrade_cfg.key => {
-      appliance = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_appliance_available_versions :
-        v.short_name => v.id
-      }, {})
-      cellular_gateway = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_cellular_gateway_available_versions :
-        v.short_name => v.id
-      }, {})
-      switch = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_available_versions :
-        v.short_name => v.id
-      }, {})
-      switch_catalyst = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_catalyst_available_versions :
-        v.short_name => v.id
-      }, {})
-      wireless = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_wireless_available_versions :
-        v.short_name => v.id
-      }, {})
-    }
+    for fw_upgrade_cfg in local.networks_firmware_available_version_lookups : fw_upgrade_cfg.key => merge(
+      try({ for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_appliance_available_versions : "appliance/${v.short_name}" => v.id }, {}),
+      try({ for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_cellular_gateway_available_versions : "cellular_gateway/${v.short_name}" => v.id }, {}),
+      try({ for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_available_versions : "switch/${v.short_name}" => v.id }, {}),
+      try({ for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_catalyst_available_versions : "switch_catalyst/${v.short_name}" => v.id }, {}),
+      try({ for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_wireless_available_versions : "wireless/${v.short_name}" => v.id }, {}),
+    )
   }
 }
 
@@ -692,26 +677,26 @@ locals {
 
           products_appliance_participate_in_next_beta_release = try(network.firmware.upgrade.products.appliance.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.appliance.participate_in_next_beta_release, null)
           products_appliance_next_upgrade_time                = try("${network.firmware.upgrade.products.appliance.next_upgrade.local_time}Z", null)
-          products_appliance_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.appliance.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].appliance[network.firmware.upgrade.products.appliance.next_upgrade.to_version]
+          products_appliance_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.appliance.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)]["appliance/${network.firmware.upgrade.products.appliance.next_upgrade.to_version}"]
 
           products_cellular_gateway_participate_in_next_beta_release = try(network.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, null)
           products_cellular_gateway_next_upgrade_time                = try("${network.firmware.upgrade.products.cellular_gateway.next_upgrade.local_time}Z", null)
-          products_cellular_gateway_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].cellular_gateway[network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version]
+          products_cellular_gateway_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)]["cellular_gateway/${network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version}"]
 
           products_switch_participate_in_next_beta_release = try(network.firmware.upgrade.products.switch.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch.participate_in_next_beta_release, null)
           # The API requires a trailing Z in the time field, but this is not true UTC — the time is interpreted in
           # the network's configured timezone. YAML stores local_time without Z; the module appends it here.
           products_switch_next_upgrade_time          = try("${network.firmware.upgrade.products.switch.next_upgrade.local_time}Z", null)
-          products_switch_next_upgrade_to_version_id = try(network.firmware.upgrade.products.switch.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].switch[network.firmware.upgrade.products.switch.next_upgrade.to_version]
+          products_switch_next_upgrade_to_version_id = try(network.firmware.upgrade.products.switch.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)]["switch/${network.firmware.upgrade.products.switch.next_upgrade.to_version}"]
 
           products_switch_catalyst_participate_in_next_beta_release = try(network.firmware.upgrade.products.switch_catalyst.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch_catalyst.participate_in_next_beta_release, null)
           products_switch_catalyst_next_upgrade_time                = try("${network.firmware.upgrade.products.switch_catalyst.next_upgrade.local_time}Z", null)
-          products_switch_catalyst_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].switch_catalyst[network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version]
+          products_switch_catalyst_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)]["switch_catalyst/${network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version}"]
 
           products_wireless_participate_in_next_beta_release = try(network.firmware.upgrade.products.wireless.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.participate_in_next_beta_release, null)
           products_wireless_next_upgrade_time                = try("${network.firmware.upgrade.products.wireless.next_upgrade.local_time}Z", null)
           products_wireless_next_upgrade_predownload_enabled = try(network.firmware.upgrade.products.wireless.next_upgrade.pre_download, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.next_upgrade.pre_download, null)
-          products_wireless_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.wireless.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].wireless[network.firmware.upgrade.products.wireless.next_upgrade.to_version]
+          products_wireless_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.wireless.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)]["wireless/${network.firmware.upgrade.products.wireless.next_upgrade.to_version}"]
           } if(
           try(network.firmware.automatic_upgrade_window, null) != null ||
           try(network.firmware.upgrade, null) != null
@@ -767,7 +752,7 @@ locals {
             }[product]
             # See upgrade locals above — Z is required by the API but does not mean UTC.
             time                = try("${product_cfg.next_downgrade.local_time}Z", null)
-            to_version_id       = try(product_cfg.next_downgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)][product][product_cfg.next_downgrade.to_version]
+            to_version_id       = try(product_cfg.next_downgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)]["${product}/${product_cfg.next_downgrade.to_version}"]
             predownload_enabled = product == "wireless" ? try(product_cfg.next_downgrade.pre_download, null) : null
             reasons = [
               for reason in try(product_cfg.next_downgrade.reasons, []) : {

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -642,32 +642,22 @@ data "meraki_network_firmware_upgrades" "networks_firmware_available_versions" {
   network_id = each.value.network_id
 }
 
-# Per-network map: {product → {short_name → id}} — resolves YAML version names to numeric IDs
+# Flat map: {"domain/org/network/product/short_name" → id} — consistent with other single-level ID lookups; resolves YAML version names to numeric IDs
 locals {
-  networks_firmware_version_maps = {
-    for fw_upgrade_cfg in local.networks_firmware_available_version_lookups : fw_upgrade_cfg.key => {
-      appliance = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_appliance_available_versions :
-        v.short_name => v.id
-      }, {})
-      cellular_gateway = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_cellular_gateway_available_versions :
-        v.short_name => v.id
-      }, {})
-      switch = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_available_versions :
-        v.short_name => v.id
-      }, {})
-      switch_catalyst = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_catalyst_available_versions :
-        v.short_name => v.id
-      }, {})
-      wireless = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_wireless_available_versions :
-        v.short_name => v.id
-      }, {})
-    }
-  }
+  networks_firmware_version_maps = { for item in flatten([
+    for fw_upgrade_cfg in local.networks_firmware_available_version_lookups : [
+      [for v in try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_appliance_available_versions, []) :
+      { key = "${fw_upgrade_cfg.key}/appliance/${v.short_name}", id = v.id }],
+      [for v in try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_cellular_gateway_available_versions, []) :
+      { key = "${fw_upgrade_cfg.key}/cellular_gateway/${v.short_name}", id = v.id }],
+      [for v in try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_available_versions, []) :
+      { key = "${fw_upgrade_cfg.key}/switch/${v.short_name}", id = v.id }],
+      [for v in try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_catalyst_available_versions, []) :
+      { key = "${fw_upgrade_cfg.key}/switch_catalyst/${v.short_name}", id = v.id }],
+      [for v in try(data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_wireless_available_versions, []) :
+      { key = "${fw_upgrade_cfg.key}/wireless/${v.short_name}", id = v.id }],
+    ]
+  ]) : item.key => item.id }
 }
 
 locals {
@@ -692,26 +682,26 @@ locals {
 
           products_appliance_participate_in_next_beta_release = try(network.firmware.upgrade.products.appliance.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.appliance.participate_in_next_beta_release, null)
           products_appliance_next_upgrade_time                = try("${network.firmware.upgrade.products.appliance.next_upgrade.local_time}Z", null)
-          products_appliance_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.appliance.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].appliance[network.firmware.upgrade.products.appliance.next_upgrade.to_version]
+          products_appliance_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.appliance.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s/appliance/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.appliance.next_upgrade.to_version)]
 
           products_cellular_gateway_participate_in_next_beta_release = try(network.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, null)
           products_cellular_gateway_next_upgrade_time                = try("${network.firmware.upgrade.products.cellular_gateway.next_upgrade.local_time}Z", null)
-          products_cellular_gateway_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].cellular_gateway[network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version]
+          products_cellular_gateway_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s/cellular_gateway/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version)]
 
           products_switch_participate_in_next_beta_release = try(network.firmware.upgrade.products.switch.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch.participate_in_next_beta_release, null)
           # The API requires a trailing Z in the time field, but this is not true UTC — the time is interpreted in
           # the network's configured timezone. YAML stores local_time without Z; the module appends it here.
           products_switch_next_upgrade_time          = try("${network.firmware.upgrade.products.switch.next_upgrade.local_time}Z", null)
-          products_switch_next_upgrade_to_version_id = try(network.firmware.upgrade.products.switch.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].switch[network.firmware.upgrade.products.switch.next_upgrade.to_version]
+          products_switch_next_upgrade_to_version_id = try(network.firmware.upgrade.products.switch.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s/switch/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.switch.next_upgrade.to_version)]
 
           products_switch_catalyst_participate_in_next_beta_release = try(network.firmware.upgrade.products.switch_catalyst.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch_catalyst.participate_in_next_beta_release, null)
           products_switch_catalyst_next_upgrade_time                = try("${network.firmware.upgrade.products.switch_catalyst.next_upgrade.local_time}Z", null)
-          products_switch_catalyst_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].switch_catalyst[network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version]
+          products_switch_catalyst_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s/switch_catalyst/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version)]
 
           products_wireless_participate_in_next_beta_release = try(network.firmware.upgrade.products.wireless.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.participate_in_next_beta_release, null)
           products_wireless_next_upgrade_time                = try("${network.firmware.upgrade.products.wireless.next_upgrade.local_time}Z", null)
           products_wireless_next_upgrade_predownload_enabled = try(network.firmware.upgrade.products.wireless.next_upgrade.pre_download, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.next_upgrade.pre_download, null)
-          products_wireless_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.wireless.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].wireless[network.firmware.upgrade.products.wireless.next_upgrade.to_version]
+          products_wireless_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.wireless.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s/wireless/%s", domain.name, organization.name, network.name, network.firmware.upgrade.products.wireless.next_upgrade.to_version)]
           } if(
           try(network.firmware.automatic_upgrade_window, null) != null ||
           try(network.firmware.upgrade, null) != null
@@ -767,7 +757,7 @@ locals {
             }[product]
             # See upgrade locals above — Z is required by the API but does not mean UTC.
             time                = try("${product_cfg.next_downgrade.local_time}Z", null)
-            to_version_id       = try(product_cfg.next_downgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)][product][product_cfg.next_downgrade.to_version]
+            to_version_id       = try(product_cfg.next_downgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s/%s/%s", domain.name, organization.name, network.name, product, product_cfg.next_downgrade.to_version)]
             predownload_enabled = product == "wireless" ? try(product_cfg.next_downgrade.pre_download, local.defaults.meraki.domains.organizations.networks.firmware.downgrade.products.wireless.next_downgrade.pre_download, null) : null
             reasons = [
               for reason in try(product_cfg.next_downgrade.reasons, []) : {

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -617,3 +617,192 @@ resource "meraki_network_webhook_http_server" "networks_webhooks_http_servers" {
   payload_template_name                = each.value.payload_template_name
   depends_on                           = [meraki_network_webhook_payload_template.networks_webhooks_payload_templates]
 }
+# ── Firmware upgrades and downgrades ──────────────────────────────────────────
+# ── Data source: read available versions per network at plan time ─────────────
+locals {
+  networks_firmware_upgrades_config = flatten([
+    for domain in try(local.meraki.domains, []) : [
+      for organization in try(domain.organizations, []) : [
+        for network in try(organization.networks, []) : {
+          key        = format("%s/%s/%s", domain.name, organization.name, network.name)
+          network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
+          } if(
+          try(network.firmware.automatic_upgrade_window, null) != null ||
+          try(network.firmware.upgrade, null) != null ||
+          try(network.firmware.downgrade, null) != null
+        )
+      ]
+    ]
+  ])
+}
+
+data "meraki_network_firmware_upgrades" "networks_firmware_data" {
+  for_each   = { for v in local.networks_firmware_upgrades_config : v.key => v }
+  network_id = each.value.network_id
+}
+
+# Per-network map: {product → {short_name → id}} — resolves YAML version names to numeric IDs
+locals {
+  networks_firmware_version_maps = {
+    for fw_upgrade_cfg in local.networks_firmware_upgrades_config : fw_upgrade_cfg.key => {
+      switch = try({
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_data[fw_upgrade_cfg.key].products_switch_available_versions :
+        v.short_name => v.id
+      }, {})
+      wireless = try({
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_data[fw_upgrade_cfg.key].products_wireless_available_versions :
+        v.short_name => v.id
+      }, {})
+      appliance = try({
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_data[fw_upgrade_cfg.key].products_appliance_available_versions :
+        v.short_name => v.id
+      }, {})
+      cellular_gateway = try({
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_data[fw_upgrade_cfg.key].products_cellular_gateway_available_versions :
+        v.short_name => v.id
+      }, {})
+      switch_catalyst = try({
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_data[fw_upgrade_cfg.key].products_switch_catalyst_available_versions :
+        v.short_name => v.id
+      }, {})
+    }
+  }
+}
+
+locals {
+  networks_firmware_upgrades = flatten([
+    for domain in try(local.meraki.domains, []) : [
+      for organization in try(domain.organizations, []) : [
+        for network in try(organization.networks, []) : {
+          key        = format("%s/%s/%s", domain.name, organization.name, network.name)
+          network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
+
+          # The API requires capitalized day names (e.g. "Sun", "Monday"). YAML stores lowercase; title() converts here.
+          upgrade_window_day_of_week = try(title(network.firmware.automatic_upgrade_window.day_of_week), title(local.defaults.meraki.domains.organizations.networks.firmware.automatic_upgrade_window.day_of_week), null)
+          upgrade_window_hour_of_day = try(network.firmware.automatic_upgrade_window.hour_of_day, local.defaults.meraki.domains.organizations.networks.firmware.automatic_upgrade_window.hour_of_day, null)
+
+          products_switch_participate_in_next_beta_release = try(network.firmware.upgrade.products.switch.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch.participate_in_next_beta_release, null)
+          # The API requires a trailing Z in the time field, but this is not true UTC — the time is interpreted in
+          # the network's configured timezone. YAML stores local_time without Z; the module appends it here.
+          products_switch_next_upgrade_time = try("${network.firmware.upgrade.products.switch.next_upgrade.local_time}Z", null)
+          products_switch_next_upgrade_to_version_id = try(
+            local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].switch[try(network.firmware.upgrade.products.switch.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch.next_upgrade.to_version, "")],
+            try(network.firmware.upgrade.products.switch.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch.next_upgrade.to_version, null)
+          )
+
+          products_switch_catalyst_participate_in_next_beta_release = try(network.firmware.upgrade.products.switch_catalyst.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch_catalyst.participate_in_next_beta_release, null)
+          products_switch_catalyst_next_upgrade_time                = try("${network.firmware.upgrade.products.switch_catalyst.next_upgrade.local_time}Z", null)
+          products_switch_catalyst_next_upgrade_to_version_id = try(
+            local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].switch_catalyst[try(network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, "")],
+            try(network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, null)
+          )
+
+          products_wireless_participate_in_next_beta_release = try(network.firmware.upgrade.products.wireless.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.participate_in_next_beta_release, null)
+          products_wireless_next_upgrade_time                = try("${network.firmware.upgrade.products.wireless.next_upgrade.local_time}Z", null)
+          products_wireless_next_upgrade_predownload_enabled = try(network.firmware.upgrade.products.wireless.next_upgrade.pre_download, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.next_upgrade.pre_download, null)
+          products_wireless_next_upgrade_to_version_id = try(
+            local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].wireless[try(network.firmware.upgrade.products.wireless.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.next_upgrade.to_version, "")],
+            try(network.firmware.upgrade.products.wireless.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.next_upgrade.to_version, null)
+          )
+
+          products_appliance_participate_in_next_beta_release = try(network.firmware.upgrade.products.appliance.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.appliance.participate_in_next_beta_release, null)
+          products_appliance_next_upgrade_time                = try("${network.firmware.upgrade.products.appliance.next_upgrade.local_time}Z", null)
+          products_appliance_next_upgrade_to_version_id = try(
+            local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].appliance[try(network.firmware.upgrade.products.appliance.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.appliance.next_upgrade.to_version, "")],
+            try(network.firmware.upgrade.products.appliance.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.appliance.next_upgrade.to_version, null)
+          )
+
+          products_cellular_gateway_participate_in_next_beta_release = try(network.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, null)
+          products_cellular_gateway_next_upgrade_time                = try("${network.firmware.upgrade.products.cellular_gateway.next_upgrade.local_time}Z", null)
+          products_cellular_gateway_next_upgrade_to_version_id = try(
+            local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].cellular_gateway[try(network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, "")],
+            try(network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, null)
+          )
+          } if(
+          try(network.firmware.automatic_upgrade_window, null) != null ||
+          try(network.firmware.upgrade, null) != null
+        )
+      ]
+    ]
+  ])
+}
+
+resource "meraki_network_firmware_upgrades" "networks_firmware_upgrades" {
+  for_each   = { for v in local.networks_firmware_upgrades : v.key => v }
+  network_id = each.value.network_id
+
+  upgrade_window_day_of_week = each.value.upgrade_window_day_of_week
+  upgrade_window_hour_of_day = each.value.upgrade_window_hour_of_day
+
+  products_switch_participate_in_next_beta_release = each.value.products_switch_participate_in_next_beta_release
+  products_switch_next_upgrade_time                = each.value.products_switch_next_upgrade_time
+  products_switch_next_upgrade_to_version_id       = each.value.products_switch_next_upgrade_to_version_id
+
+  products_switch_catalyst_participate_in_next_beta_release = each.value.products_switch_catalyst_participate_in_next_beta_release
+  products_switch_catalyst_next_upgrade_time                = each.value.products_switch_catalyst_next_upgrade_time
+  products_switch_catalyst_next_upgrade_to_version_id       = each.value.products_switch_catalyst_next_upgrade_to_version_id
+
+  products_wireless_participate_in_next_beta_release = each.value.products_wireless_participate_in_next_beta_release
+  products_wireless_next_upgrade_time                = each.value.products_wireless_next_upgrade_time
+  products_wireless_next_upgrade_predownload_enabled = each.value.products_wireless_next_upgrade_predownload_enabled
+  products_wireless_next_upgrade_to_version_id       = each.value.products_wireless_next_upgrade_to_version_id
+
+  products_appliance_participate_in_next_beta_release = each.value.products_appliance_participate_in_next_beta_release
+  products_appliance_next_upgrade_time                = each.value.products_appliance_next_upgrade_time
+  products_appliance_next_upgrade_to_version_id       = each.value.products_appliance_next_upgrade_to_version_id
+
+  products_cellular_gateway_participate_in_next_beta_release = each.value.products_cellular_gateway_participate_in_next_beta_release
+  products_cellular_gateway_next_upgrade_time                = each.value.products_cellular_gateway_next_upgrade_time
+  products_cellular_gateway_next_upgrade_to_version_id       = each.value.products_cellular_gateway_next_upgrade_to_version_id
+}
+
+locals {
+  networks_firmware_rollbacks = flatten([
+    for domain in try(local.meraki.domains, []) : [
+      for organization in try(domain.organizations, []) : [
+        for network in try(organization.networks, []) : [
+          for product, product_cfg in {
+            switch          = try(network.firmware.downgrade.products.switch, null)
+            switchCatalyst  = try(network.firmware.downgrade.products.switch_catalyst, null)
+            wireless        = try(network.firmware.downgrade.products.wireless, null)
+            appliance       = try(network.firmware.downgrade.products.appliance, null)
+            cellularGateway = try(network.firmware.downgrade.products.cellular_gateway, null)
+            } : {
+            key        = format("%s/%s/%s/%s", domain.name, organization.name, network.name, product)
+            network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
+            product    = product
+            # See upgrade locals above — Z is required by the API but does not mean UTC.
+            time = try("${product_cfg.next_downgrade.local_time}Z", null)
+            to_version_id = try(
+              local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)][{
+                switch          = "switch"
+                switchCatalyst  = "switch_catalyst"
+                wireless        = "wireless"
+                appliance       = "appliance"
+                cellularGateway = "cellular_gateway"
+              }[product]][try(product_cfg.next_downgrade.to_version, "")],
+              try(product_cfg.next_downgrade.to_version, null)
+            )
+            predownload_enabled = product == "wireless" ? try(product_cfg.next_downgrade.pre_download, local.defaults.meraki.domains.organizations.networks.firmware.downgrade.products.wireless.next_downgrade.pre_download, null) : null
+            reasons = try(product_cfg.next_downgrade.reasons, null) == null ? null : [
+              for reason in try(product_cfg.next_downgrade.reasons, []) : {
+                category = try(reason.category, null)
+                comment  = try(reason.comment, null)
+              }
+            ]
+          } if product_cfg != null
+        ] if try(network.firmware.downgrade, null) != null
+      ]
+    ]
+  ])
+}
+
+resource "meraki_network_firmware_upgrades_rollback" "networks_firmware_rollbacks" {
+  for_each            = { for v in local.networks_firmware_rollbacks : v.key => v }
+  network_id          = each.value.network_id
+  product             = each.value.product
+  time                = each.value.time
+  to_version_id       = each.value.to_version_id
+  predownload_enabled = each.value.predownload_enabled
+  reasons             = each.value.reasons
+}

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -768,7 +768,7 @@ locals {
             # See upgrade locals above — Z is required by the API but does not mean UTC.
             time                = try("${product_cfg.next_downgrade.local_time}Z", null)
             to_version_id       = try(product_cfg.next_downgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)][product][product_cfg.next_downgrade.to_version]
-            predownload_enabled = try(product_cfg.next_downgrade.pre_download, null)
+            predownload_enabled = product == "wireless" ? try(product_cfg.next_downgrade.pre_download, null) : null
             reasons = [
               for reason in try(product_cfg.next_downgrade.reasons, []) : {
                 category = try(reason.category, null)

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -642,16 +642,31 @@ data "meraki_network_firmware_upgrades" "networks_firmware_available_versions" {
   network_id = each.value.network_id
 }
 
-# Per-network map: {"product/short_name" → id} — resolves YAML version names to numeric IDs
+# Per-network map: {product → {short_name → id}} — resolves YAML version names to numeric IDs
 locals {
   networks_firmware_version_maps = {
-    for fw_upgrade_cfg in local.networks_firmware_available_version_lookups : fw_upgrade_cfg.key => merge(
-      try({ for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_appliance_available_versions : "appliance/${v.short_name}" => v.id }, {}),
-      try({ for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_cellular_gateway_available_versions : "cellular_gateway/${v.short_name}" => v.id }, {}),
-      try({ for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_available_versions : "switch/${v.short_name}" => v.id }, {}),
-      try({ for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_catalyst_available_versions : "switch_catalyst/${v.short_name}" => v.id }, {}),
-      try({ for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_wireless_available_versions : "wireless/${v.short_name}" => v.id }, {}),
-    )
+    for fw_upgrade_cfg in local.networks_firmware_available_version_lookups : fw_upgrade_cfg.key => {
+      appliance = try({
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_appliance_available_versions :
+        v.short_name => v.id
+      }, {})
+      cellular_gateway = try({
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_cellular_gateway_available_versions :
+        v.short_name => v.id
+      }, {})
+      switch = try({
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_available_versions :
+        v.short_name => v.id
+      }, {})
+      switch_catalyst = try({
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_catalyst_available_versions :
+        v.short_name => v.id
+      }, {})
+      wireless = try({
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_wireless_available_versions :
+        v.short_name => v.id
+      }, {})
+    }
   }
 }
 
@@ -677,26 +692,26 @@ locals {
 
           products_appliance_participate_in_next_beta_release = try(network.firmware.upgrade.products.appliance.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.appliance.participate_in_next_beta_release, null)
           products_appliance_next_upgrade_time                = try("${network.firmware.upgrade.products.appliance.next_upgrade.local_time}Z", null)
-          products_appliance_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.appliance.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)]["appliance/${network.firmware.upgrade.products.appliance.next_upgrade.to_version}"]
+          products_appliance_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.appliance.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].appliance[network.firmware.upgrade.products.appliance.next_upgrade.to_version]
 
           products_cellular_gateway_participate_in_next_beta_release = try(network.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, null)
           products_cellular_gateway_next_upgrade_time                = try("${network.firmware.upgrade.products.cellular_gateway.next_upgrade.local_time}Z", null)
-          products_cellular_gateway_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)]["cellular_gateway/${network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version}"]
+          products_cellular_gateway_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].cellular_gateway[network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version]
 
           products_switch_participate_in_next_beta_release = try(network.firmware.upgrade.products.switch.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch.participate_in_next_beta_release, null)
           # The API requires a trailing Z in the time field, but this is not true UTC — the time is interpreted in
           # the network's configured timezone. YAML stores local_time without Z; the module appends it here.
           products_switch_next_upgrade_time          = try("${network.firmware.upgrade.products.switch.next_upgrade.local_time}Z", null)
-          products_switch_next_upgrade_to_version_id = try(network.firmware.upgrade.products.switch.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)]["switch/${network.firmware.upgrade.products.switch.next_upgrade.to_version}"]
+          products_switch_next_upgrade_to_version_id = try(network.firmware.upgrade.products.switch.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].switch[network.firmware.upgrade.products.switch.next_upgrade.to_version]
 
           products_switch_catalyst_participate_in_next_beta_release = try(network.firmware.upgrade.products.switch_catalyst.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch_catalyst.participate_in_next_beta_release, null)
           products_switch_catalyst_next_upgrade_time                = try("${network.firmware.upgrade.products.switch_catalyst.next_upgrade.local_time}Z", null)
-          products_switch_catalyst_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)]["switch_catalyst/${network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version}"]
+          products_switch_catalyst_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].switch_catalyst[network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version]
 
           products_wireless_participate_in_next_beta_release = try(network.firmware.upgrade.products.wireless.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.participate_in_next_beta_release, null)
           products_wireless_next_upgrade_time                = try("${network.firmware.upgrade.products.wireless.next_upgrade.local_time}Z", null)
           products_wireless_next_upgrade_predownload_enabled = try(network.firmware.upgrade.products.wireless.next_upgrade.pre_download, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.next_upgrade.pre_download, null)
-          products_wireless_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.wireless.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)]["wireless/${network.firmware.upgrade.products.wireless.next_upgrade.to_version}"]
+          products_wireless_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.wireless.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].wireless[network.firmware.upgrade.products.wireless.next_upgrade.to_version]
           } if(
           try(network.firmware.automatic_upgrade_window, null) != null ||
           try(network.firmware.upgrade, null) != null
@@ -752,7 +767,7 @@ locals {
             }[product]
             # See upgrade locals above — Z is required by the API but does not mean UTC.
             time                = try("${product_cfg.next_downgrade.local_time}Z", null)
-            to_version_id       = try(product_cfg.next_downgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)]["${product}/${product_cfg.next_downgrade.to_version}"]
+            to_version_id       = try(product_cfg.next_downgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)][product][product_cfg.next_downgrade.to_version]
             predownload_enabled = product == "wireless" ? try(product_cfg.next_downgrade.pre_download, null) : null
             reasons = [
               for reason in try(product_cfg.next_downgrade.reasons, []) : {

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -617,52 +617,53 @@ resource "meraki_network_webhook_http_server" "networks_webhooks_http_servers" {
   payload_template_name                = each.value.payload_template_name
   depends_on                           = [meraki_network_webhook_payload_template.networks_webhooks_payload_templates]
 }
-# ── Firmware upgrades and downgrades ──────────────────────────────────────────
-# ── Data source: read available versions per network at plan time ─────────────
+
 locals {
-  networks_firmware_upgrades_config = flatten([
+  networks_firmware_available_version_lookups = flatten([
     for domain in try(local.meraki.domains, []) : [
       for organization in try(domain.organizations, []) : [
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
           } if(
-          try(network.firmware.automatic_upgrade_window, null) != null ||
-          try(network.firmware.upgrade, null) != null ||
-          try(network.firmware.downgrade, null) != null
+          anytrue([
+            for product in ["appliance", "cellular_gateway", "switch", "switch_catalyst", "wireless"] :
+            try(network.firmware.upgrade.products[product].next_upgrade.to_version, null) != null ||
+            try(network.firmware.downgrade.products[product].next_downgrade.to_version, null) != null
+          ])
         )
       ]
     ]
   ])
 }
 
-data "meraki_network_firmware_upgrades" "networks_firmware_data" {
-  for_each   = { for v in local.networks_firmware_upgrades_config : v.key => v }
+data "meraki_network_firmware_upgrades" "networks_firmware_available_versions" {
+  for_each   = { for v in local.networks_firmware_available_version_lookups : v.key => v }
   network_id = each.value.network_id
 }
 
 # Per-network map: {product → {short_name → id}} — resolves YAML version names to numeric IDs
 locals {
   networks_firmware_version_maps = {
-    for fw_upgrade_cfg in local.networks_firmware_upgrades_config : fw_upgrade_cfg.key => {
-      switch = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_data[fw_upgrade_cfg.key].products_switch_available_versions :
-        v.short_name => v.id
-      }, {})
-      wireless = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_data[fw_upgrade_cfg.key].products_wireless_available_versions :
-        v.short_name => v.id
-      }, {})
+    for fw_upgrade_cfg in local.networks_firmware_available_version_lookups : fw_upgrade_cfg.key => {
       appliance = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_data[fw_upgrade_cfg.key].products_appliance_available_versions :
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_appliance_available_versions :
         v.short_name => v.id
       }, {})
       cellular_gateway = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_data[fw_upgrade_cfg.key].products_cellular_gateway_available_versions :
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_cellular_gateway_available_versions :
+        v.short_name => v.id
+      }, {})
+      switch = try({
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_available_versions :
         v.short_name => v.id
       }, {})
       switch_catalyst = try({
-        for v in data.meraki_network_firmware_upgrades.networks_firmware_data[fw_upgrade_cfg.key].products_switch_catalyst_available_versions :
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_switch_catalyst_available_versions :
+        v.short_name => v.id
+      }, {})
+      wireless = try({
+        for v in data.meraki_network_firmware_upgrades.networks_firmware_available_versions[fw_upgrade_cfg.key].products_wireless_available_versions :
         v.short_name => v.id
       }, {})
     }
@@ -670,7 +671,7 @@ locals {
 }
 
 locals {
-  networks_firmware_upgrades = flatten([
+  networks_firmware = flatten([
     for domain in try(local.meraki.domains, []) : [
       for organization in try(domain.organizations, []) : [
         for network in try(organization.networks, []) : {
@@ -681,43 +682,28 @@ locals {
           upgrade_window_day_of_week = try(title(network.firmware.automatic_upgrade_window.day_of_week), title(local.defaults.meraki.domains.organizations.networks.firmware.automatic_upgrade_window.day_of_week), null)
           upgrade_window_hour_of_day = try(network.firmware.automatic_upgrade_window.hour_of_day, local.defaults.meraki.domains.organizations.networks.firmware.automatic_upgrade_window.hour_of_day, null)
 
+          products_appliance_participate_in_next_beta_release = try(network.firmware.upgrade.products.appliance.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.appliance.participate_in_next_beta_release, null)
+          products_appliance_next_upgrade_time                = try("${network.firmware.upgrade.products.appliance.next_upgrade.local_time}Z", null)
+          products_appliance_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.appliance.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].appliance[network.firmware.upgrade.products.appliance.next_upgrade.to_version]
+
+          products_cellular_gateway_participate_in_next_beta_release = try(network.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, null)
+          products_cellular_gateway_next_upgrade_time                = try("${network.firmware.upgrade.products.cellular_gateway.next_upgrade.local_time}Z", null)
+          products_cellular_gateway_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].cellular_gateway[network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version]
+
           products_switch_participate_in_next_beta_release = try(network.firmware.upgrade.products.switch.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch.participate_in_next_beta_release, null)
           # The API requires a trailing Z in the time field, but this is not true UTC — the time is interpreted in
           # the network's configured timezone. YAML stores local_time without Z; the module appends it here.
-          products_switch_next_upgrade_time = try("${network.firmware.upgrade.products.switch.next_upgrade.local_time}Z", null)
-          products_switch_next_upgrade_to_version_id = try(
-            local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].switch[try(network.firmware.upgrade.products.switch.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch.next_upgrade.to_version, "")],
-            try(network.firmware.upgrade.products.switch.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch.next_upgrade.to_version, null)
-          )
+          products_switch_next_upgrade_time          = try("${network.firmware.upgrade.products.switch.next_upgrade.local_time}Z", null)
+          products_switch_next_upgrade_to_version_id = try(network.firmware.upgrade.products.switch.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].switch[network.firmware.upgrade.products.switch.next_upgrade.to_version]
 
           products_switch_catalyst_participate_in_next_beta_release = try(network.firmware.upgrade.products.switch_catalyst.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch_catalyst.participate_in_next_beta_release, null)
           products_switch_catalyst_next_upgrade_time                = try("${network.firmware.upgrade.products.switch_catalyst.next_upgrade.local_time}Z", null)
-          products_switch_catalyst_next_upgrade_to_version_id = try(
-            local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].switch_catalyst[try(network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, "")],
-            try(network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, null)
-          )
+          products_switch_catalyst_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].switch_catalyst[network.firmware.upgrade.products.switch_catalyst.next_upgrade.to_version]
 
           products_wireless_participate_in_next_beta_release = try(network.firmware.upgrade.products.wireless.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.participate_in_next_beta_release, null)
           products_wireless_next_upgrade_time                = try("${network.firmware.upgrade.products.wireless.next_upgrade.local_time}Z", null)
           products_wireless_next_upgrade_predownload_enabled = try(network.firmware.upgrade.products.wireless.next_upgrade.pre_download, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.next_upgrade.pre_download, null)
-          products_wireless_next_upgrade_to_version_id = try(
-            local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].wireless[try(network.firmware.upgrade.products.wireless.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.next_upgrade.to_version, "")],
-            try(network.firmware.upgrade.products.wireless.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.wireless.next_upgrade.to_version, null)
-          )
-
-          products_appliance_participate_in_next_beta_release = try(network.firmware.upgrade.products.appliance.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.appliance.participate_in_next_beta_release, null)
-          products_appliance_next_upgrade_time                = try("${network.firmware.upgrade.products.appliance.next_upgrade.local_time}Z", null)
-          products_appliance_next_upgrade_to_version_id = try(
-            local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].appliance[try(network.firmware.upgrade.products.appliance.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.appliance.next_upgrade.to_version, "")],
-            try(network.firmware.upgrade.products.appliance.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.appliance.next_upgrade.to_version, null)
-          )
-
-          products_cellular_gateway_participate_in_next_beta_release = try(network.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.cellular_gateway.participate_in_next_beta_release, null)
-          products_cellular_gateway_next_upgrade_time                = try("${network.firmware.upgrade.products.cellular_gateway.next_upgrade.local_time}Z", null)
-          products_cellular_gateway_next_upgrade_to_version_id = try(
-            local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].cellular_gateway[try(network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, "")],
-            try(network.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, local.defaults.meraki.domains.organizations.networks.firmware.upgrade.products.cellular_gateway.next_upgrade.to_version, null)
-          )
+          products_wireless_next_upgrade_to_version_id       = try(network.firmware.upgrade.products.wireless.next_upgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)].wireless[network.firmware.upgrade.products.wireless.next_upgrade.to_version]
           } if(
           try(network.firmware.automatic_upgrade_window, null) != null ||
           try(network.firmware.upgrade, null) != null
@@ -727,12 +713,20 @@ locals {
   ])
 }
 
-resource "meraki_network_firmware_upgrades" "networks_firmware_upgrades" {
-  for_each   = { for v in local.networks_firmware_upgrades : v.key => v }
+resource "meraki_network_firmware_upgrades" "networks_firmware" {
+  for_each   = { for v in local.networks_firmware : v.key => v }
   network_id = each.value.network_id
 
   upgrade_window_day_of_week = each.value.upgrade_window_day_of_week
   upgrade_window_hour_of_day = each.value.upgrade_window_hour_of_day
+
+  products_appliance_participate_in_next_beta_release = each.value.products_appliance_participate_in_next_beta_release
+  products_appliance_next_upgrade_time                = each.value.products_appliance_next_upgrade_time
+  products_appliance_next_upgrade_to_version_id       = each.value.products_appliance_next_upgrade_to_version_id
+
+  products_cellular_gateway_participate_in_next_beta_release = each.value.products_cellular_gateway_participate_in_next_beta_release
+  products_cellular_gateway_next_upgrade_time                = each.value.products_cellular_gateway_next_upgrade_time
+  products_cellular_gateway_next_upgrade_to_version_id       = each.value.products_cellular_gateway_next_upgrade_to_version_id
 
   products_switch_participate_in_next_beta_release = each.value.products_switch_participate_in_next_beta_release
   products_switch_next_upgrade_time                = each.value.products_switch_next_upgrade_time
@@ -746,59 +740,42 @@ resource "meraki_network_firmware_upgrades" "networks_firmware_upgrades" {
   products_wireless_next_upgrade_time                = each.value.products_wireless_next_upgrade_time
   products_wireless_next_upgrade_predownload_enabled = each.value.products_wireless_next_upgrade_predownload_enabled
   products_wireless_next_upgrade_to_version_id       = each.value.products_wireless_next_upgrade_to_version_id
-
-  products_appliance_participate_in_next_beta_release = each.value.products_appliance_participate_in_next_beta_release
-  products_appliance_next_upgrade_time                = each.value.products_appliance_next_upgrade_time
-  products_appliance_next_upgrade_to_version_id       = each.value.products_appliance_next_upgrade_to_version_id
-
-  products_cellular_gateway_participate_in_next_beta_release = each.value.products_cellular_gateway_participate_in_next_beta_release
-  products_cellular_gateway_next_upgrade_time                = each.value.products_cellular_gateway_next_upgrade_time
-  products_cellular_gateway_next_upgrade_to_version_id       = each.value.products_cellular_gateway_next_upgrade_to_version_id
 }
 
 locals {
-  networks_firmware_rollbacks = flatten([
+  networks_firmware_downgrade = flatten([
     for domain in try(local.meraki.domains, []) : [
       for organization in try(domain.organizations, []) : [
         for network in try(organization.networks, []) : [
-          for product, product_cfg in {
-            switch          = try(network.firmware.downgrade.products.switch, null)
-            switchCatalyst  = try(network.firmware.downgrade.products.switch_catalyst, null)
-            wireless        = try(network.firmware.downgrade.products.wireless, null)
-            appliance       = try(network.firmware.downgrade.products.appliance, null)
-            cellularGateway = try(network.firmware.downgrade.products.cellular_gateway, null)
-            } : {
+          for product, product_cfg in try(network.firmware.downgrade.products, {}) : {
             key        = format("%s/%s/%s/%s", domain.name, organization.name, network.name, product)
             network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-            product    = product
+            product = {
+              appliance        = "appliance"
+              cellular_gateway = "cellularGateway"
+              switch           = "switch"
+              switch_catalyst  = "switchCatalyst"
+              wireless         = "wireless"
+            }[product]
             # See upgrade locals above — Z is required by the API but does not mean UTC.
-            time = try("${product_cfg.next_downgrade.local_time}Z", null)
-            to_version_id = try(
-              local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)][{
-                switch          = "switch"
-                switchCatalyst  = "switch_catalyst"
-                wireless        = "wireless"
-                appliance       = "appliance"
-                cellularGateway = "cellular_gateway"
-              }[product]][try(product_cfg.next_downgrade.to_version, "")],
-              try(product_cfg.next_downgrade.to_version, null)
-            )
-            predownload_enabled = product == "wireless" ? try(product_cfg.next_downgrade.pre_download, local.defaults.meraki.domains.organizations.networks.firmware.downgrade.products.wireless.next_downgrade.pre_download, null) : null
-            reasons = try(product_cfg.next_downgrade.reasons, null) == null ? null : [
+            time                = try("${product_cfg.next_downgrade.local_time}Z", null)
+            to_version_id       = try(product_cfg.next_downgrade.to_version, null) == null ? null : local.networks_firmware_version_maps[format("%s/%s/%s", domain.name, organization.name, network.name)][product][product_cfg.next_downgrade.to_version]
+            predownload_enabled = try(product_cfg.next_downgrade.pre_download, null)
+            reasons = [
               for reason in try(product_cfg.next_downgrade.reasons, []) : {
                 category = try(reason.category, null)
                 comment  = try(reason.comment, null)
               }
             ]
-          } if product_cfg != null
-        ] if try(network.firmware.downgrade, null) != null
+          }
+        ]
       ]
     ]
   ])
 }
 
-resource "meraki_network_firmware_upgrades_rollback" "networks_firmware_rollbacks" {
-  for_each            = { for v in local.networks_firmware_rollbacks : v.key => v }
+resource "meraki_network_firmware_upgrades_rollback" "networks_firmware_downgrade" {
+  for_each            = { for v in local.networks_firmware_downgrade : v.key => v }
   network_id          = each.value.network_id
   product             = each.value.product
   time                = each.value.time

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -678,7 +678,7 @@ locals {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
 
-          # The API requires capitalized day names (e.g. "Sun", "Monday"). YAML stores lowercase; title() converts here.
+          # The API requires short title-case day names (e.g. "Sun", "Mon"). YAML stores lowercase long form (e.g. "sunday", "monday"); the map converts here and fails explicitly on an unrecognised value.
           upgrade_window_day_of_week = try(network.firmware.automatic_upgrade_window.day_of_week, local.defaults.meraki.domains.organizations.networks.firmware.automatic_upgrade_window.day_of_week, null) == null ? null : {
             sunday    = "Sun"
             monday    = "Mon"


### PR DESCRIPTION
## Summary

Adds firmware upgrade and downgrade management for Meraki networks.

- **`meraki_network_firmware_upgrades`** — schedules firmware upgrades across \`switch\`, \`switch_catalyst\`, \`wireless\`, \`appliance\`, and \`cellular_gateway\`. Supports \`automatic_upgrade_window\`, per-product \`local_time\`, \`to_version\`, \`participate_in_next_beta_release\`, and wireless \`predownload_enabled\`.
- **`meraki_network_firmware_upgrades_rollback`** — schedules per-product downgrades via the \`/rollback\` endpoint with required \`reasons\` (category + comment).
- **`meraki_network_firmware_upgrades`** (data source) — fetches available firmware versions at plan time per network, used to resolve human-readable version short names (e.g. \`MS 17.2.2\`) to numeric provider IDs.
- \`local_time\` is stored in YAML without a timezone designator; the module appends \`Z\` before passing to the API (the API requires trailing Z but interprets the time in the network's configured timezone, not UTC).
- \`upgrade_window_day_of_week\` is stored in YAML as lowercase (e.g. \`sun\`, \`monday\`); the module applies \`title()\` before passing to the API, which only accepts capitalized form.
- Networks with only a \`downgrade\` block are included in the version map data source so rollback version resolution works correctly.

Aligned with [CiscoDevNet/terraform-provider-meraki#253](https://github.com/CiscoDevNet/terraform-provider-meraki/pull/253).

Related NAC issue: netascode/nac-meraki#2008

## Test plan

- [x] \`terraform plan\` with firmware upgrade YAML produces the expected resource diff
- [x] \`terraform apply\` schedules an upgrade and a downgrade on a test network
- [x] Downgrade with \`reasons\` applies correctly
- [x] Networks without a \`firmware\` block produce no firmware resources