### PR TITLE
feat(appliance): opt-in force_replace_on_change for static routes

### DIFF
--- a/meraki_appliance.tf
+++ b/meraki_appliance.tf
@@ -859,7 +859,22 @@ locals {
       for organization in try(domain.organizations, []) : [
         for network in try(organization.networks, []) : [
           for appliance_static_route in try(network.appliance.static_routes, []) : {
-            key             = format("%s/%s/%s/%s", domain.name, organization.name, network.name, appliance_static_route.name)
+            # When force_replace_on_change is true, a short hash of the next-hop-defining
+            # fields is appended to the key. Any change to gateway_ip/gateway_vlan_id/subnet
+            # then changes the key, forcing a destroy+create instead of an in-place update.
+            # This materializes a destroy node so the existing depends_on edge
+            # (meraki_appliance_vlan destroy -> meraki_appliance_static_route destroy) orders
+            # the route removal before the old VLAN is deleted during a transit-VLAN migration.
+            key = format("%s/%s/%s/%s%s",
+              domain.name, organization.name, network.name, appliance_static_route.name,
+              try(appliance_static_route.force_replace_on_change, false) ? format("#%s",
+                substr(md5(format("%s|%s|%s",
+                  try(appliance_static_route.gateway_ip, ""),
+                  try(appliance_static_route.gateway_vlan_id, ""),
+                  try(appliance_static_route.subnet, "")
+                )), 0, 8)
+              ) : ""
+            )
             network_id      = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
             name            = try(appliance_static_route.name, local.defaults.meraki.domains.organizations.networks.appliance.static_routes.name, null)
             subnet          = try(appliance_static_route.subnet, local.defaults.meraki.domains.organizations.networks.appliance.static_routes.subnet, null)


### PR DESCRIPTION
## Problem
Migrating an MX transit VLAN (e.g. VLAN 21 → 22) while its static-route next hop moves between subnets fails with **"invalid next hop IP"**. Static routes are keyed by name, so a next-hop change is an in-place *update* (no destroy node). Terraform's `depends_on` only orders route-*destroy* before VLAN-*destroy* — an update gets no such edge — so the old VLAN can be deleted before the route is repointed.

## Change
Add an **opt-in** `force_replace_on_change` boolean to appliance static routes. When `true`, a short hash of `gateway_ip|gateway_vlan_id|subnet` is appended to the `for_each` key, so any next-hop/subnet change forces a **destroy+create**. That materializes a destroy node, and the existing `meraki_appliance_vlan (destroy) -> meraki_appliance_static_route (destroy)` edge then orders route removal **before** the old VLAN is deleted.

## Backward compatibility
Flag absent/`false` → byte-for-byte identical resource keys and in-place-update behavior as today. No change for existing users.

## Testing
- `terraform fmt` / `validate` / `tflint` / `terraform-docs` pass (pre-commit).
- Exercised via the nac-meraki CX integration fixtures (companion change points the fixtures at this branch): a VLAN swap + route repoint plans as VLAN create, VLAN destroy, route **replace**, with route-destroy ordered before VLAN-destroy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
