### PR TITLE
fix: claim warm spare device after primary to enforce HA role order

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ module "meraki" {
 | [meraki_device_management_interface.devices_management_interface](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/device_management_interface) | resource |
 | [meraki_network.organizations_networks](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network) | resource |
 | [meraki_network_device_claim.networks_devices_claim](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_device_claim) | resource |
+| [meraki_network_device_claim.networks_devices_claim_spare](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_device_claim) | resource |
 | [meraki_network_floor_plan.networks_floor_plans](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_floor_plan) | resource |
 | [meraki_network_group_policy.networks_group_policies](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_group_policy) | resource |
 | [meraki_network_netflow.networks_netflow](https://registry.terraform.io/providers/CiscoDevNet/meraki/latest/docs/resources/network_netflow) | resource |

--- a/meraki_networks.tf
+++ b/meraki_networks.tf
@@ -371,7 +371,10 @@ locals {
         for network in try(organization.networks, []) : {
           key        = format("%s/%s/%s", domain.name, organization.name, network.name)
           network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
-          serials    = [for d in network.devices : d.serial]
+          serials = [
+            for d in network.devices : d.serial
+            if d.name != try(network.appliance.warm_spare.spare_device, "")
+          ]
         } if try(network.devices, null) != null
       ]
     ]
@@ -382,6 +385,30 @@ resource "meraki_network_device_claim" "networks_devices_claim" {
   for_each   = { for v in local.networks_devices_claim : v.key => v }
   network_id = each.value.network_id
   serials    = each.value.serials
+}
+
+locals {
+  networks_devices_claim_spare = flatten([
+    for domain in try(local.meraki.domains, []) : [
+      for organization in try(domain.organizations, []) : [
+        for network in try(organization.networks, []) : {
+          key        = format("%s/%s/%s", domain.name, organization.name, network.name)
+          network_id = local.organizations_network_ids[format("%s/%s/%s", domain.name, organization.name, network.name)]
+          serials = [
+            for d in network.devices : d.serial
+            if d.name == network.appliance.warm_spare.spare_device
+          ]
+        } if try(network.devices, null) != null && try(network.appliance.warm_spare.spare_device, null) != null
+      ]
+    ]
+  ])
+}
+
+resource "meraki_network_device_claim" "networks_devices_claim_spare" {
+  for_each   = { for v in local.networks_devices_claim_spare : v.key => v }
+  network_id = each.value.network_id
+  serials    = each.value.serials
+  depends_on = [meraki_network_device_claim.networks_devices_claim]
 }
 
 locals {


### PR DESCRIPTION
## Summary

- Splits `meraki_network_device_claim` into two ordered resources so the intended primary MX device always registers before the spare.
- Networks without `appliance.warm_spare.spare_device` are unaffected — all their devices are still claimed in the single original resource.

## Problem

When deploying an MX Warm Spare pair, the Meraki Dashboard assigns the **primary role to whichever device is claimed first** — not based on any explicit configuration. Because Terraform claimed all devices in a single `meraki_network_device_claim` resource with no ordering guarantee, registration order was non-deterministic (dependent on network timing and provider internals). This meant the device configured as `spare_device` could end up as primary, causing the subsequent `meraki_appliance_warm_spare` configuration to fail or produce an inconsistent HA state.

Reported against customer BBVA. Tracked in: https://wwwin-github.cisco.com/netascode/nac-meraki/issues/2015

## Solution

**Before:** All device serials for a network were collected into one list and claimed together.

```hcl
serials = [for d in network.devices : d.serial]
```

**After:** The spare device (identified by name via `appliance.warm_spare.spare_device`) is excluded from the primary claim and claimed separately in a second resource that `depends_on` the first.

```hcl
# Primary claim — excludes the spare device
serials = [
  for d in network.devices : d.serial
  if d.name != try(network.appliance.warm_spare.spare_device, "")
]

# Spare claim — runs only after primary claim completes
resource "meraki_network_device_claim" "networks_devices_claim_spare" {
  ...
  depends_on = [meraki_network_device_claim.networks_devices_claim]
}
```

This guarantees the intended primary device registers first and assumes the primary role in the Dashboard, so `meraki_appliance_warm_spare` always finds the spare serial in the correct slot.

## Impact

- Networks with `appliance.warm_spare.spare_device` set: spare device is now claimed in a separate, sequenced resource.
- Networks without warm spare config: no change — single resource, all devices claimed as before.
- Existing state: users with an already-deployed warm spare pair where roles are already correct will see no drift. Users in the broken state (roles swapped) will need to re-apply after correcting their serial assignments.

## Test plan

- [ ] Deploy a new network with two MX devices and `appliance.warm_spare.spare_device` set — verify the named spare ends up as spare in the Dashboard.
- [ ] Deploy a network without warm spare config — verify all devices are claimed normally in a single resource.
- [ ] Run `terraform plan` against an existing deployment with correct roles — verify no unexpected changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)