### PR TITLE
docs: add CHANGELOG entry for 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 
+## 0.10.0
+
+New Features:
+
+- Add support for `meraki_network_vlan_profile_assignment` — per-network VLAN profile assignments with a `vlan_profile_iname` and optional lists of `devices` (resolved to serials) and `stacks` (resolved to stack IDs) (https://github.com/netascode/terraform-meraki-nac-meraki/pull/166)
+- Add support for network firmware upgrades and downgrades — `meraki_network_firmware_upgrades` (schedule upgrades across `switch`, `switch_catalyst`, `wireless`, `appliance`, and `cellular_gateway`), `meraki_network_firmware_upgrades_rollback` (per-product downgrades with required `reasons`), and a `meraki_network_firmware_upgrades` data source that resolves human-readable version short names to provider IDs at plan time (https://github.com/netascode/terraform-meraki-nac-meraki/pull/176)
+
+Minimum Required Providers:
+
+- Raise the required `netascode/utils` provider constraint to `~> 2.0` and `hashicorp/local` to `~> 2.9` in `modules/model/versions.tf`. Consumers pinned to an older `utils` provider must upgrade. (https://github.com/netascode/terraform-meraki-nac-meraki/pull/174)
+
+Bug Fixes:
+
+- Fix passing required lists of dicts (https://github.com/netascode/terraform-meraki-nac-meraki/pull/173)
+- Fix `networks_wireless_rf_profiles` `per_ssid_settings.bands` handling (https://github.com/netascode/terraform-meraki-nac-meraki/pull/177)
+
 ## 0.9.0
 
 New Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 
 New Features:
 
-- Add support for `meraki_network_vlan_profile_assignment` — per-network VLAN profile assignments with a `vlan_profile_iname` and optional lists of `devices` (resolved to serials) and `stacks` (resolved to stack IDs) (https://github.com/netascode/terraform-meraki-nac-meraki/pull/166)
-- Add support for network firmware upgrades and downgrades — `meraki_network_firmware_upgrades` (schedule upgrades across `switch`, `switch_catalyst`, `wireless`, `appliance`, and `cellular_gateway`), `meraki_network_firmware_upgrades_rollback` (per-product downgrades with required `reasons`), and a `meraki_network_firmware_upgrades` data source that resolves human-readable version short names to provider IDs at plan time (https://github.com/netascode/terraform-meraki-nac-meraki/pull/176)
+- Add support for `networks_vlan_profiles_assignments` (https://github.com/netascode/terraform-meraki-nac-meraki/pull/166)
+- Add support for network firmware upgrades and downgrades — `networks_firmware` (schedule upgrades across `switch`, `switch_catalyst`, `wireless`, `appliance`, and `cellular_gateway` and configure Dashboard's automatic upgrade window / per-product next beta release opt-in), `networks_firmware_downgrade` (per-product downgrades with required `reasons`) (https://github.com/netascode/terraform-meraki-nac-meraki/pull/176)
 
 Minimum Required Providers:
 


### PR DESCRIPTION
Adds the `## 0.10.0` CHANGELOG section covering the changes on `main` since `v0.9.0`, plus the firmware upgrades/downgrades module (#176) merging as part of this release.

### New Features
- `meraki_network_vlan_profile_assignment` — per-network VLAN profile assignments with a `vlan_profile_iname` and optional `devices` (→ serials) / `stacks` (→ stack IDs) (#166)
- Network firmware upgrades and downgrades — `meraki_network_firmware_upgrades`, `meraki_network_firmware_upgrades_rollback`, and a `meraki_network_firmware_upgrades` data source that resolves version short names to provider IDs at plan time (#176)

### Minimum Required Providers
- Raise `netascode/utils` to `~> 2.0` and `hashicorp/local` to `~> 2.9` in `modules/model/versions.tf` (#174)

### Bug Fixes
- Fix passing required lists of dicts (#173)
- Fix `networks_wireless_rf_profiles` `per_ssid_settings.bands` handling (#177)

Changelog-only change; no module/resource code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)