### PR TITLE
Add support for device-level configuration templates (meraki.templates.devices)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## Unreleased
+
+New Features:
+
+- Add support for device-level configuration templates (meraki.templates.devices), applied per-device via devices.templates/devices.variables — mirrors existing network template support (issue #2022)
+
 ## 0.10.0
 
 New Features:

--- a/modules/model/README.md
+++ b/modules/model/README.md
@@ -28,7 +28,7 @@ module "model" {
 | Name | Version |
 |------|---------|
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.9 |
 
 ## Inputs
 

--- a/modules/model/README.md
+++ b/modules/model/README.md
@@ -28,7 +28,7 @@ module "model" {
 | Name | Version |
 |------|---------|
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
-| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.9 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
 
 ## Inputs
 

--- a/modules/model/main.tf
+++ b/modules/model/main.tf
@@ -6,7 +6,14 @@ locals {
       configuration : template.type == "model" ? replace(yamlencode(template.configuration), "/\"([$%]{.*})\"/", "$1") : "${path.root}/${template.file}"
     }
   ]
-  meraki = {
+  templates_devices = [
+    for template in try(local.model.meraki.templates.devices, []) : {
+      name : template.name,
+      type : template.type,
+      configuration : template.type == "model" ? replace(yamlencode(template.configuration), "/\"([$%]{.*})\"/", "$1") : "${path.root}/${template.file}"
+    }
+  ]
+  networks_templated = {
     meraki = {
       domains = [
         for domain in try(local.model.meraki.domains, []) : merge(
@@ -22,6 +29,38 @@ locals {
                       [for t in try(network.templates, []) : [for template in local.templates_networks : (template.type == "model" ? templatestring(template.configuration, try(network.variables, {})) : templatefile(template.configuration, try(network.variables, {}))) if template.name == t][0]],
                       [yamlencode(network)]
                     )))
+                  ]
+                }
+              )
+            ]
+          }
+        )
+      ]
+    }
+  }
+  meraki = {
+    meraki = {
+      domains = [
+        for domain in try(local.networks_templated.meraki.domains, []) : merge(
+          { for k, v in domain : k => v if k != "organizations" },
+          {
+            organizations = [
+              for organization in try(domain.organizations, []) : merge(
+                { for k, v in organization : k => v if k != "networks" },
+                {
+                  networks = [
+                    for network in try(organization.networks, []) : merge(
+                      { for k, v in network : k => v if k != "devices" },
+                      {
+                        devices = [
+                          for device in try(network.devices, []) :
+                          yamldecode(provider::utils::yaml_merge(concat(
+                            [for t in try(device.templates, []) : [for template in local.templates_devices : (template.type == "model" ? templatestring(template.configuration, try(device.variables, {})) : templatefile(template.configuration, try(device.variables, {}))) if template.name == t][0]],
+                            [yamlencode(device)]
+                          )))
+                        ]
+                      }
+                    )
                   ]
                 }
               )


### PR DESCRIPTION
## Summary

- Adds device-level configuration templates, mirroring the existing network-level template feature (`meraki.templates.networks`) — see [netascode/nac-meraki#2022](https://wwwin-github.cisco.com/netascode/nac-meraki/issues/2022).
- `modules/model/main.tf` is restructured into two passes: the existing network-template merge (renamed to the `networks_templated` local, unchanged logic) feeds into a second pass that merges `meraki.templates.devices` entries onto each network's `devices` list, using each device's own `templates`/`variables` fields.
- Same semantics as network templates: `model` (inline YAML via `templatestring`) and `file` (`.tftpl` via `templatefile`, path resolved relative to `path.root`) template types, `${variable}` placeholders, `!env` for secrets, and "list is ordered, last wins" merge precedence.
- No new module inputs/outputs — this is pure data-model resolution inside `modules/model`, same as the network template feature required.

Companion schema/docs/test changes are in [netascode/nac-meraki#2022](https://wwwin-github.cisco.com/netascode/nac-meraki/pull/2022) (internal GHE) — without those, `templates.devices`/`devices.templates`/`devices.variables` would fail schema validation even though this module supports them.

## Test plan

- [x] `terraform fmt` — no diff
- [x] `terraform validate` on `modules/model` — passes
- [x] Manually exercised via a scratch config pointing at this branch's `modules/model`, with a network containing a device referencing a `templates.devices` entry — confirmed the rendered `write_model_file` output shows the device's template config merged in, with `${variable}` placeholders resolved from the device's own `variables` block
- [x] CI / existing module tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)